### PR TITLE
docs(release): mark v0.1.177+custom.001 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -37,7 +37,7 @@ procedures are documented in [`docs/RELEASING.md`](docs/RELEASING.md).
 | `v0.1.173+custom.004` | `v0.1.173` | `29009f0b2ea14edf3b11ae2564fb617ff91a03b4` | published |
 | `v0.1.176+custom.001` | `v0.1.176` | `e803e3851c0a7e222cfadeafad7b8636ab959d11` | published |
 | `v0.1.176+custom.002` | `v0.1.176` | `e803e3851c0a7e222cfadeafad7b8636ab959d11` | published |
-| `v0.1.177+custom.001` | `v0.1.177` | `073e92d17178a1ccdb0a27017f572f10c9c7ab62` | planned |
+| `v0.1.177+custom.001` | `v0.1.177` | `073e92d17178a1ccdb0a27017f572f10c9c7ab62` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.1.177-custom.001` after the repository local-validation gate.

## Validation

- Platform-container validation matrix passed.

<!-- sub2api-submit-pr: {"base":"2f2dbcb444bb2329ef463ab30900ca050be3f0bc","head":"283f57e455ce94342bfe18a7c95d726df90d7fff"} -->
