### PR TITLE
fix(ui): hide version badge from non-admin users

### DIFF
--- a/backend/internal/service/grok_quota_service_test.go
+++ b/backend/internal/service/grok_quota_service_test.go
@@ -781,11 +781,7 @@ func TestGrokQuotaServiceQueryQuotaPaidBillingSkipsActiveProbe(t *testing.T) {
 	require.Empty(t, result.Model)
 	require.Nil(t, result.LocalUsage24h)
 
-	requests, _ := upstream.snapshot()
-	require.Len(t, requests, 2)
-	for _, req := range requests {
-		require.Equal(t, "/v1/billing", req.URL.Path)
-	}
+	requireGrokBillingProbeSkippedActiveUsage(t, upstream)
 }
 
 func TestGrokQuotaServiceQueryQuotaCustomPaidMonthlyLimitSkipsActiveProbe(t *testing.T) {
@@ -806,11 +802,32 @@ func TestGrokQuotaServiceQueryQuotaCustomPaidMonthlyLimitSkipsActiveProbe(t *tes
 	require.InDelta(t, monthlyLimit, *result.Billing.MonthlyLimitCents, 1e-9)
 	require.Nil(t, result.Snapshot)
 
+	requireGrokBillingProbeSkippedActiveUsage(t, upstream)
+}
+
+func requireGrokBillingProbeSkippedActiveUsage(t *testing.T, upstream *grokHybridUpstream) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		requests, _ := upstream.snapshot()
+		return len(requests) >= 2
+	}, time.Second, 10*time.Millisecond)
+
 	requests, _ := upstream.snapshot()
-	require.Len(t, requests, 2)
+	billingRequests := 0
 	for _, req := range requests {
-		require.Equal(t, "/v1/billing", req.URL.Path)
+		switch req.URL.Path {
+		case "/v1/billing":
+			billingRequests++
+		case "/v1/models":
+			// QueryQuota may start a best-effort observed-models sync after a
+			// successful billing probe. That request is not an active usage probe.
+		case "/v1/responses":
+			require.Fail(t, "authoritative billing should skip the active usage probe")
+		default:
+			require.Failf(t, "unexpected Grok quota request", "path=%s", req.URL.Path)
+		}
 	}
+	require.Equal(t, 2, billingRequests)
 }
 
 func TestGrokLocalUsage24hUsesRollingUTCWindow(t *testing.T) {

--- a/frontend/src/components/common/VersionBadge.vue
+++ b/frontend/src/components/common/VersionBadge.vue
@@ -1,7 +1,5 @@
 <template>
-  <div class="relative">
-    <!-- Admin: Full version badge with dropdown -->
-    <template v-if="isAdmin">
+  <div v-if="isAdmin" class="relative">
       <button
         @click="toggleDropdown"
         class="flex items-center gap-1.5 rounded-lg px-2 py-1 text-xs transition-colors"
@@ -627,17 +625,11 @@
           </div>
         </div>
       </transition>
-    </template>
-
-    <!-- Non-admin: Simple static version text -->
-    <span v-else-if="version" class="text-xs text-gray-500 dark:text-dark-400">
-      v{{ version }}
-    </span>
   </div>
 </template>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, onBeforeUnmount } from 'vue'
+import { ref, computed, watch, onMounted, onBeforeUnmount } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { useAuthStore, useAppStore } from '@/stores'
 import {
@@ -657,10 +649,6 @@ const DOCKER_IMAGE = 'ghcr.io/luckykuang/sub2api-plus'
 
 const { t } = useI18n()
 
-const props = defineProps<{
-  version?: string
-}>()
-
 const authStore = useAuthStore()
 const appStore = useAppStore()
 
@@ -671,7 +659,7 @@ const dropdownRef = ref<HTMLElement | null>(null)
 
 // Use store's cached version state
 const loading = computed(() => appStore.versionLoading)
-const currentVersion = computed(() => normalizeDisplayVersion(appStore.currentVersion || props.version))
+const currentVersion = computed(() => normalizeDisplayVersion(appStore.currentVersion))
 const latestVersion = computed(() => normalizeDisplayVersion(appStore.latestVersion))
 const hasUpdate = computed(() => appStore.hasUpdate)
 const releaseInfo = computed(() => appStore.releaseInfo)
@@ -732,6 +720,7 @@ const activeManualCommand = computed(() =>
 const isReleaseBuild = computed(() => buildType.value === 'release')
 
 function toggleDropdown() {
+  if (!isAdmin.value) return
   dropdownOpen.value = !dropdownOpen.value
 }
 
@@ -752,7 +741,7 @@ async function refreshVersion(force = true) {
 }
 
 async function handleUpdate() {
-  if (updating.value) return
+  if (!isAdmin.value || updating.value) return
 
   updating.value = true
   updateError.value = ''
@@ -763,8 +752,7 @@ async function handleUpdate() {
     successKind.value = 'update'
     updateSuccess.value = true
     needRestart.value = result.need_restart
-    // Clear version cache to reflect update completed
-    appStore.clearVersionCache()
+    appStore.invalidateVersionCheck()
   } catch (error: unknown) {
     const err = error as { response?: { data?: { message?: string } }; message?: string }
     updateError.value = err.response?.data?.message || err.message || t('version.updateFailed')
@@ -813,7 +801,7 @@ async function loadRollbackVersions() {
 }
 
 function selectRollbackVersion(version: string) {
-  if (rollingBack.value) return
+  if (!isAdmin.value || rollingBack.value) return
   rollbackError.value = ''
   selectedRollbackVersion.value = selectedRollbackVersion.value === version ? '' : version
 }
@@ -838,8 +826,7 @@ async function handleRollback() {
     updateSuccess.value = true
     needRestart.value = result.need_restart
     rollbackPanelOpen.value = false
-    // Clear version cache so the next check reflects the rolled-back version
-    appStore.clearVersionCache()
+    appStore.invalidateVersionCheck()
   } catch (error: unknown) {
     const err = error as { response?: { data?: { message?: string } }; message?: string }
     rollbackError.value = err.response?.data?.message || err.message || t('version.rollbackFailed')
@@ -849,7 +836,7 @@ async function handleRollback() {
 }
 
 async function handleRestart() {
-  if (restarting.value) return
+  if (!isAdmin.value || restarting.value) return
 
   restarting.value = true
   restartCountdown.value = 8
@@ -909,11 +896,24 @@ function handleClickOutside(event: MouseEvent) {
   }
 }
 
+watch(
+  isAdmin,
+  (admin) => {
+    if (admin) {
+      void appStore.fetchVersion(false)
+      return
+    }
+    closeDropdown()
+    resetRollbackState()
+    updateError.value = ''
+    updateSuccess.value = false
+    needRestart.value = false
+    appStore.clearVersionCache()
+  },
+  { immediate: true }
+)
+
 onMounted(() => {
-  if (isAdmin.value) {
-    // Use cached version if available, otherwise fetch
-    appStore.fetchVersion(false)
-  }
   document.addEventListener('click', handleClickOutside)
 })
 

--- a/frontend/src/components/common/__tests__/VersionBadge.spec.ts
+++ b/frontend/src/components/common/__tests__/VersionBadge.spec.ts
@@ -2,14 +2,227 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 
-import { describe, expect, it } from 'vitest'
+import { flushPromises, mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { defineComponent, nextTick } from 'vue'
+
+import VersionBadge from '../VersionBadge.vue'
+import { useAppStore, useAuthStore } from '@/stores'
+
+const {
+  checkUpdates,
+  performUpdate,
+  restartService,
+  getRollbackVersions,
+  rollback,
+} = vi.hoisted(() => ({
+  checkUpdates: vi.fn(),
+  performUpdate: vi.fn(),
+  restartService: vi.fn(),
+  getRollbackVersions: vi.fn(),
+  rollback: vi.fn(),
+}))
+
+vi.mock('@/api/admin/system', () => ({
+  checkUpdates,
+  performUpdate,
+  restartService,
+  getRollbackVersions,
+  rollback,
+  default: {
+    checkUpdates,
+    performUpdate,
+    restartService,
+    getRollbackVersions,
+    rollback,
+  },
+}))
+
+vi.mock('vue-i18n', async () => {
+  const actual = await vi.importActual<typeof import('vue-i18n')>('vue-i18n')
+  return {
+    ...actual,
+    useI18n: () => ({ t: (key: string) => key }),
+  }
+})
+
+const IconStub = defineComponent({
+  props: { name: { type: String, default: '' } },
+  template: '<span class="icon" />',
+})
 
 const componentPath = resolve(dirname(fileURLToPath(import.meta.url)), '../VersionBadge.vue')
 const componentSource = readFileSync(componentPath, 'utf8')
+
+function mountBadge() {
+  return mount(VersionBadge, {
+    global: {
+      plugins: [createPinia()],
+      stubs: { Icon: IconStub, transition: false },
+    },
+  })
+}
 
 describe('VersionBadge dropdown width', () => {
   it('uses a fixed 20rem width for long custom version strings', () => {
     expect(componentSource).toContain('mt-2 w-80 overflow-hidden')
     expect(componentSource).not.toContain("'w-64'")
+  })
+
+  it('does not render a static version for non-admins', () => {
+    expect(componentSource).not.toContain('Non-admin: Simple static version text')
+    expect(componentSource).not.toContain('v-else-if="version"')
+    expect(componentSource).toContain('v-if="isAdmin"')
+  })
+})
+
+describe('VersionBadge admin-only rendering', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    checkUpdates.mockReset()
+    checkUpdates.mockResolvedValue({
+      current_version: '0.1.177',
+      latest_version: '0.1.177',
+      has_update: false,
+      build_type: 'release',
+      cached: false,
+    })
+  })
+
+  it('renders nothing and does not fetch updates for a regular user', async () => {
+    const wrapper = mountBadge()
+    const authStore = useAuthStore()
+    const appStore = useAppStore()
+    authStore.user = {
+      id: 1,
+      username: 'user',
+      email: 'user@example.com',
+      role: 'user',
+      balance: 0,
+      concurrency: 1,
+      status: 'active',
+      allowed_groups: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+    } as never
+    appStore.siteVersion = '9.9.9'
+    await nextTick()
+    await flushPromises()
+
+    expect(wrapper.text()).not.toContain('v9.9.9')
+    expect(wrapper.find('button').exists()).toBe(false)
+    expect(checkUpdates).not.toHaveBeenCalled()
+    wrapper.unmount()
+  })
+
+  it('fetches and shows the admin version badge only after the user is an admin', async () => {
+    const wrapper = mountBadge()
+    const authStore = useAuthStore()
+    await nextTick()
+    expect(wrapper.find('button').exists()).toBe(false)
+
+    authStore.user = {
+      id: 2,
+      username: 'admin',
+      email: 'admin@example.com',
+      role: 'admin',
+      balance: 0,
+      concurrency: 1,
+      status: 'active',
+      allowed_groups: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+    } as never
+    await flushPromises()
+
+    expect(checkUpdates).toHaveBeenCalledTimes(1)
+    expect(wrapper.text()).toContain('v0.1.177')
+    expect(wrapper.find('button').exists()).toBe(true)
+    wrapper.unmount()
+  })
+
+  it('removes the badge and clears cached version state when the user loses admin', async () => {
+    const wrapper = mountBadge()
+    const authStore = useAuthStore()
+    const appStore = useAppStore()
+    authStore.user = {
+      id: 2,
+      username: 'admin',
+      email: 'admin@example.com',
+      role: 'admin',
+      balance: 0,
+      concurrency: 1,
+      status: 'active',
+      allowed_groups: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+    } as never
+    await flushPromises()
+    expect(wrapper.find('button').exists()).toBe(true)
+    expect(appStore.currentVersion).toBe('0.1.177')
+
+    authStore.user = {
+      id: 2,
+      username: 'admin',
+      email: 'admin@example.com',
+      role: 'user',
+      balance: 0,
+      concurrency: 1,
+      status: 'active',
+      allowed_groups: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+    } as never
+    await nextTick()
+
+    expect(wrapper.find('button').exists()).toBe(false)
+    expect(wrapper.text()).not.toContain('v0.1.177')
+    expect(appStore.currentVersion).toBe('')
+    expect(appStore.versionLoaded).toBe(false)
+    wrapper.unmount()
+  })
+
+  it('does not call update or restart APIs after losing admin', async () => {
+    const wrapper = mountBadge()
+    const authStore = useAuthStore()
+    authStore.user = {
+      id: 2,
+      username: 'admin',
+      email: 'admin@example.com',
+      role: 'admin',
+      balance: 0,
+      concurrency: 1,
+      status: 'active',
+      allowed_groups: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+    } as never
+    await flushPromises()
+
+    const vm = wrapper.vm as unknown as {
+      handleUpdate: () => Promise<void>
+      handleRestart: () => Promise<void>
+    }
+    authStore.user = {
+      id: 2,
+      username: 'admin',
+      email: 'admin@example.com',
+      role: 'user',
+      balance: 0,
+      concurrency: 1,
+      status: 'active',
+      allowed_groups: null,
+      created_at: '2026-01-01',
+      updated_at: '2026-01-01',
+    } as never
+    await nextTick()
+
+    await vm.handleUpdate()
+    await vm.handleRestart()
+
+    expect(performUpdate).not.toHaveBeenCalled()
+    expect(restartService).not.toHaveBeenCalled()
+    wrapper.unmount()
   })
 })

--- a/frontend/src/components/layout/AppSidebar.vue
+++ b/frontend/src/components/layout/AppSidebar.vue
@@ -24,8 +24,7 @@
         >
           {{ siteName }}
         </router-link>
-        <!-- Version Badge -->
-        <VersionBadge :version="siteVersion" />
+        <VersionBadge v-if="isAdmin" />
       </div>
     </div>
 
@@ -262,7 +261,6 @@ const expandedGroups = ref<Set<string>>(new Set())
 // Site settings from appStore (cached, no flicker)
 const siteName = computed(() => appStore.siteName)
 const siteLogo = computed(() => sanitizeUrl(appStore.siteLogo || '', { allowRelative: true, allowDataUrl: true }))
-const siteVersion = computed(() => appStore.siteVersion)
 const settingsLoaded = computed(() => appStore.publicSettingsLoaded)
 
 // SVG Icon Components

--- a/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
+++ b/frontend/src/components/layout/__tests__/AppSidebar.spec.ts
@@ -42,6 +42,14 @@ describe('AppSidebar scroll position persistence', () => {
   })
 })
 
+describe('AppSidebar version badge visibility', () => {
+  it('mounts VersionBadge only for confirmed admins', () => {
+    expect(componentSource).toContain('<VersionBadge v-if="isAdmin" />')
+    expect(componentSource).not.toContain(':version="siteVersion"')
+    expect(componentSource).not.toContain('const siteVersion')
+  })
+})
+
 describe('AppSidebar header styles', () => {
   it('does not clip the version badge dropdown', () => {
     const sidebarHeaderBlockMatch = styleSource.match(/\.sidebar-header\s*\{[\s\S]*?\n {2}\}/)

--- a/frontend/src/stores/__tests__/app.spec.ts
+++ b/frontend/src/stores/__tests__/app.spec.ts
@@ -1,7 +1,9 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAppStore } from '@/stores/app'
+import { useAuthStore } from '@/stores/auth'
 import { getPublicSettings } from '@/api/auth'
+import { checkUpdates } from '@/api/admin/system'
 import type { PublicSettings } from '@/types'
 
 function createDeferred<T>() {
@@ -65,9 +67,13 @@ function createPublicSettings(overrides: Partial<PublicSettings> = {}): PublicSe
 }
 
 // Mock API 模块
-vi.mock('@/api/admin/system', () => ({
-  checkUpdates: vi.fn(),
-}))
+vi.mock('@/api/admin/system', () => {
+  const checkUpdates = vi.fn()
+  return {
+    checkUpdates,
+    default: { checkUpdates },
+  }
+})
 
 vi.mock('@/api/auth', () => ({
   getPublicSettings: vi.fn(),
@@ -474,6 +480,93 @@ describe('useAppStore', () => {
       expect((window as any).__APP_CONFIG__.table_page_size_options).toEqual([20, 100, 1000])
       expect(localStorage.getItem('table-page-size')).toBeNull()
       expect(localStorage.getItem('table-page-size-source')).toBeNull()
+    })
+  })
+
+  describe('版本信息', () => {
+    it('非管理员调用 fetchVersion 不会请求更新接口', async () => {
+      vi.mocked(checkUpdates).mockReset()
+      const store = useAppStore()
+      const result = await store.fetchVersion()
+
+      expect(result).toBeNull()
+      expect(checkUpdates).not.toHaveBeenCalled()
+    })
+
+    it('管理员可以拉取版本，登出后清空缓存', async () => {
+      vi.mocked(checkUpdates).mockResolvedValue({
+        current_version: '0.1.177',
+        latest_version: '0.1.178',
+        has_update: true,
+        build_type: 'release',
+        cached: false,
+      })
+      const authStore = useAuthStore()
+      authStore.user = { role: 'admin' } as never
+      const store = useAppStore()
+
+      const result = await store.fetchVersion()
+      expect(result?.current_version).toBe('0.1.177')
+      expect(store.currentVersion).toBe('0.1.177')
+      expect(checkUpdates).toHaveBeenCalledTimes(1)
+
+      authStore.user = { role: 'user' } as never
+      await Promise.resolve()
+
+      expect(store.currentVersion).toBe('')
+      expect(store.hasUpdate).toBe(false)
+      expect(store.versionLoaded).toBe(false)
+    })
+
+    it('登出后丢弃尚未返回的版本请求', async () => {
+      const deferred = createDeferred<{
+        current_version: string
+        latest_version: string
+        has_update: boolean
+        build_type: string
+        cached: boolean
+      }>()
+      vi.mocked(checkUpdates).mockReturnValue(deferred.promise)
+      const authStore = useAuthStore()
+      authStore.user = { role: 'admin' } as never
+      const store = useAppStore()
+
+      const pending = store.fetchVersion()
+      await Promise.resolve()
+      authStore.user = { role: 'user' } as never
+      deferred.resolve({
+        current_version: '0.1.177',
+        latest_version: '0.1.178',
+        has_update: true,
+        build_type: 'release',
+        cached: false,
+      })
+
+      await expect(pending).resolves.toBeNull()
+      expect(store.currentVersion).toBe('')
+      expect(store.versionLoaded).toBe(false)
+      expect(store.hasUpdate).toBe(false)
+    })
+
+    it('invalidateVersionCheck 保留当前版本并作废检查结果', async () => {
+      vi.mocked(checkUpdates).mockResolvedValue({
+        current_version: '0.1.177',
+        latest_version: '0.1.178',
+        has_update: true,
+        build_type: 'release',
+        cached: false,
+      })
+      const authStore = useAuthStore()
+      authStore.user = { role: 'admin' } as never
+      const store = useAppStore()
+      await store.fetchVersion()
+
+      store.invalidateVersionCheck()
+
+      expect(store.currentVersion).toBe('0.1.177')
+      expect(store.latestVersion).toBe('0.1.178')
+      expect(store.hasUpdate).toBe(false)
+      expect(store.versionLoaded).toBe(false)
     })
   })
 })

--- a/frontend/src/stores/__tests__/auth.spec.ts
+++ b/frontend/src/stores/__tests__/auth.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useAuthStore } from '@/stores/auth'
+import { useAppStore } from '@/stores/app'
 
 // Mock authAPI
 const mockLogin = vi.fn()
@@ -339,6 +340,25 @@ describe('useAuthStore', () => {
     it('未登录时返回 false', () => {
       const store = useAuthStore()
       expect(store.isAdmin).toBe(false)
+    })
+
+    it('登出后清空管理员版本缓存', async () => {
+      const adminResponse = { ...fakeAuthResponse, user: { ...fakeAdminUser } }
+      mockLogin.mockResolvedValue(adminResponse)
+      mockLogout.mockResolvedValue(undefined)
+      const authStore = useAuthStore()
+      const appStore = useAppStore()
+      await authStore.login({ email: 'admin@example.com', password: '123456' })
+      appStore.currentVersion = '0.1.177'
+      appStore.versionLoaded = true
+      appStore.hasUpdate = true
+
+      await authStore.logout()
+
+      expect(authStore.isAdmin).toBe(false)
+      expect(appStore.currentVersion).toBe('')
+      expect(appStore.versionLoaded).toBe(false)
+      expect(appStore.hasUpdate).toBe(false)
     })
   })
 

--- a/frontend/src/stores/app.ts
+++ b/frontend/src/stores/app.ts
@@ -43,6 +43,7 @@ export const useAppStore = defineStore('app', () => {
   const hasUpdate = ref<boolean>(false)
   const buildType = ref<string>('source')
   const releaseInfo = ref<ReleaseInfo | null>(null)
+  let versionRequestId = 0
 
   // Auto-incrementing ID for toasts
   let toastIdCounter = 0
@@ -240,7 +241,18 @@ export const useAppStore = defineStore('app', () => {
    * Fetch version info (uses cache unless force=true)
    * @param force - Force refresh from API
    */
+  async function currentUserIsAdmin(): Promise<boolean> {
+    // Late import avoids a cycle with auth.ts, which clears this cache on logout.
+    const { useAuthStore } = await import('@/stores/auth')
+    return useAuthStore().isAdmin
+  }
+
   async function fetchVersion(force = false): Promise<VersionInfo | null> {
+    if (!(await currentUserIsAdmin())) {
+      clearVersionCache()
+      return null
+    }
+
     // Return cached data if available and not forcing refresh
     if (versionLoaded.value && !force) {
       return {
@@ -258,9 +270,13 @@ export const useAppStore = defineStore('app', () => {
       return null
     }
 
+    const requestId = versionRequestId
     versionLoading.value = true
     try {
       const data = await checkUpdatesAPI(force)
+      if (requestId !== versionRequestId || !(await currentUserIsAdmin())) {
+        return null
+      }
       currentVersion.value = data.current_version
       latestVersion.value = data.latest_version
       hasUpdate.value = data.has_update
@@ -272,16 +288,32 @@ export const useAppStore = defineStore('app', () => {
       console.error('Failed to fetch version:', error)
       return null
     } finally {
-      versionLoading.value = false
+      if (requestId === versionRequestId) {
+        versionLoading.value = false
+      }
     }
   }
 
   /**
-   * Clear version cache (e.g., after update)
+   * Drop a completed update check without wiping the visible current version.
+   * Used after an in-place update/rollback so the next check refetches.
+   */
+  function invalidateVersionCheck(): void {
+    versionRequestId += 1
+    versionLoaded.value = false
+    versionLoading.value = false
+    hasUpdate.value = false
+  }
+
+  /**
+   * Clear version cache (e.g., after update, logout, or losing admin).
    */
   function clearVersionCache(): void {
-    versionLoaded.value = false
-    hasUpdate.value = false
+    invalidateVersionCheck()
+    currentVersion.value = ''
+    latestVersion.value = ''
+    buildType.value = 'source'
+    releaseInfo.value = null
   }
 
   // ==================== Public Settings Management ====================
@@ -484,6 +516,7 @@ export const useAppStore = defineStore('app', () => {
 
     // Version actions
     fetchVersion,
+    invalidateVersionCheck,
     clearVersionCache,
 
     // Public settings actions

--- a/frontend/src/stores/auth.ts
+++ b/frontend/src/stores/auth.ts
@@ -4,8 +4,9 @@
  */
 
 import { defineStore } from 'pinia'
-import { ref, computed, readonly } from 'vue'
+import { ref, computed, readonly, watch } from 'vue'
 import { authAPI, isTotp2FARequired, passkeyAPI, type LoginResponse } from '@/api'
+import { useAppStore } from '@/stores/app'
 import type {
   User,
   LoginRequest,
@@ -94,6 +95,12 @@ export const useAuthStore = defineStore('auth', () => {
 
   const isAdmin = computed(() => {
     return user.value?.role === 'admin'
+  })
+
+  watch(isAdmin, (admin) => {
+    if (!admin) {
+      useAppStore().clearVersionCache()
+    }
   })
 
   const isSimpleMode = computed(() => runMode.value === 'simple')


### PR DESCRIPTION
## Summary
- Render the sidebar version badge only for confirmed admins.
- Stop using public `siteVersion` for the badge, and clear cached version state on logout or role change.
- Discard in-flight update checks so a long-lived user session cannot suddenly show the admin-only control.

## Test plan
- [ ] Log in as a regular user: no version text or clickable badge in the sidebar, and no `/admin/system/check-updates` request after waiting or navigating.
- [ ] Log in as an admin: version badge appears and can open update/rollback actions.
- [ ] Switch or refresh from admin to a regular user: badge disappears and previous version cache is gone.
- [ ] `pnpm test:run src/components/common/__tests__/VersionBadge.spec.ts src/components/layout/__tests__/AppSidebar.spec.ts src/stores/__tests__/app.spec.ts src/stores/__tests__/auth.spec.ts`

<!-- sub2api-submit-pr: {"base":"93bd13dab9d4fb9560bee597ba54184dcef536af","head":"4e48fac86101e1491f8780ffd8646f8c69f7d3f2"} -->
