### PR TITLE
docs(ip-access): add Cloudflare Real IP steps to deploy guide

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,8 +1,10 @@
 # 确保所有 SQL 迁移文件使用 LF 换行符
 backend/migrations/*.sql text eol=lf
 
-# Go 源代码文件
+# Go 源代码和模块文件
 *.go text eol=lf
+go.mod text eol=lf
+go.sum text eol=lf
 
 # 前端 源代码文件
 *.ts text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,9 @@ backend/migrations/*.sql text eol=lf
 # Shell 脚本
 *.sh text eol=lf
 
+# 无扩展名的 Shell 测试夹具
+deploy/tests/fixtures/bin/* text eol=lf
+
 # YAML/YML 配置文件
 *.yaml text eol=lf
 *.yml text eol=lf

--- a/backend/internal/service/grok_quota_service_test.go
+++ b/backend/internal/service/grok_quota_service_test.go
@@ -781,11 +781,7 @@ func TestGrokQuotaServiceQueryQuotaPaidBillingSkipsActiveProbe(t *testing.T) {
 	require.Empty(t, result.Model)
 	require.Nil(t, result.LocalUsage24h)
 
-	requests, _ := upstream.snapshot()
-	require.Len(t, requests, 2)
-	for _, req := range requests {
-		require.Equal(t, "/v1/billing", req.URL.Path)
-	}
+	requireGrokBillingProbeSkippedActiveUsage(t, upstream)
 }
 
 func TestGrokQuotaServiceQueryQuotaCustomPaidMonthlyLimitSkipsActiveProbe(t *testing.T) {
@@ -806,11 +802,32 @@ func TestGrokQuotaServiceQueryQuotaCustomPaidMonthlyLimitSkipsActiveProbe(t *tes
 	require.InDelta(t, monthlyLimit, *result.Billing.MonthlyLimitCents, 1e-9)
 	require.Nil(t, result.Snapshot)
 
+	requireGrokBillingProbeSkippedActiveUsage(t, upstream)
+}
+
+func requireGrokBillingProbeSkippedActiveUsage(t *testing.T, upstream *grokHybridUpstream) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		requests, _ := upstream.snapshot()
+		return len(requests) >= 2
+	}, time.Second, 10*time.Millisecond)
+
 	requests, _ := upstream.snapshot()
-	require.Len(t, requests, 2)
+	billingRequests := 0
 	for _, req := range requests {
-		require.Equal(t, "/v1/billing", req.URL.Path)
+		switch req.URL.Path {
+		case "/v1/billing":
+			billingRequests++
+		case "/v1/models":
+			// QueryQuota may start a best-effort observed-models sync after a
+			// successful billing probe. That request is not an active usage probe.
+		case "/v1/responses":
+			require.Fail(t, "authoritative billing should skip the active usage probe")
+		default:
+			require.Failf(t, "unexpected Grok quota request", "path=%s", req.URL.Path)
+		}
 	}
+	require.Equal(t, 2, billingRequests)
 }
 
 func TestGrokLocalUsage24hUsesRollingUTCWindow(t *testing.T) {

--- a/deploy/tests/apple-container-test.sh
+++ b/deploy/tests/apple-container-test.sh
@@ -19,6 +19,15 @@ fail() {
     exit 1
 }
 
+assert_lf_shebang() {
+    local fixture=$1
+    local shebang
+
+    IFS= read -r shebang <"${fixture}"
+    [[ "${shebang}" == '#!/bin/bash' ]] || \
+        fail "Executable fixture must use an LF shebang: ${fixture}"
+}
+
 assert_exists() {
     [[ -e "$1" ]] || fail "Expected path to exist: $1"
 }
@@ -39,6 +48,9 @@ export PATH="${TEST_DIR}/fixtures/bin:${PATH}"
 export SUB2API_ENV_FILE="${ENV_FILE}"
 
 mkdir -p "${STATE_DIR}"
+
+assert_lf_shebang "${TEST_DIR}/fixtures/bin/container"
+assert_lf_shebang "${TEST_DIR}/fixtures/bin/curl"
 
 file_mode() {
     stat -c '%a' "$1" 2>/dev/null || stat -f '%Lp' "$1"

--- a/frontend/src/i18n/locales/en/admin/ipAccessControl.ts
+++ b/frontend/src/i18n/locales/en/admin/ipAccessControl.ts
@@ -143,15 +143,20 @@ export default {
       standaloneStep1: 'Write the same server.trusted_proxies field used by the official binary.',
       standaloneStep2: 'Stop the old process and start a new one. Reloading the web page does not load this list.',
       proxyTitle: 'The reverse proxy must sanitize forwarding headers',
-      proxyHint: 'The app accepts exactly one address from the direct trusted proxy. Do not use $proxy_add_x_forwarded_for.',
+      proxyHint: 'The app accepts exactly one address from the direct trusted proxy. Do not use $proxy_add_x_forwarded_for. If you only rewrite headers and skip Real IP, the resolved client IP will be a Cloudflare egress address such as 162.158.* or 172.64–172.71.',
+      proxyCloudflareHint: 'For Cloudflare orange-cloud, first confirm nginx -V includes --with-http_realip_module. Then enable Nginx Real IP in the http block and list official Cloudflare CIDRs with set_real_ip_from. A comment is not a configuration. Recheck https://www.cloudflare.com/ips-v4 and https://www.cloudflare.com/ips-v6 before going live.',
+      proxyCloudflareHttp: 'underscores_in_headers on;\n\nreal_ip_header CF-Connecting-IP;\nreal_ip_recursive on;\n\nset_real_ip_from 173.245.48.0/20;\nset_real_ip_from 103.21.244.0/22;\nset_real_ip_from 103.22.200.0/22;\nset_real_ip_from 103.31.4.0/22;\nset_real_ip_from 141.101.64.0/18;\nset_real_ip_from 108.162.192.0/18;\nset_real_ip_from 190.93.240.0/20;\nset_real_ip_from 188.114.96.0/20;\nset_real_ip_from 197.234.240.0/22;\nset_real_ip_from 198.41.128.0/17;\nset_real_ip_from 162.158.0.0/15;\nset_real_ip_from 104.16.0.0/13;\nset_real_ip_from 104.24.0.0/14;\nset_real_ip_from 172.64.0.0/13;\nset_real_ip_from 131.0.72.0/22;\n\nset_real_ip_from 2400:cb00::/32;\nset_real_ip_from 2606:4700::/32;\nset_real_ip_from 2803:f800::/32;\nset_real_ip_from 2405:b500::/32;\nset_real_ip_from 2405:8100::/32;\nset_real_ip_from 2a06:98c0::/29;\nset_real_ip_from 2c0f:f248::/32;',
+      proxyHeaderHint: 'After Real IP is applied, $remote_addr is the client public IP. Overwrite headers on every proxy_pass route; do not append:',
       proxyNginx: 'proxy_set_header X-Real-IP $remote_addr;\nproxy_set_header X-Forwarded-For $remote_addr;\nproxy_set_header CF-Connecting-IP "";',
+      proxyVerify: 'Run nginx -t and reload. Confirm the http block has real directives with nginx -T | grep -E \'real_ip_header|set_real_ip_from\'. Back on this page, the resolved client IP must be your public address, not 162.158.* or 172.64–172.71.',
+      proxyTunnelHint: 'For Cloudflare Tunnel, public Cloudflare CIDRs do not connect to Nginx. set_real_ip_from must list the actual cloudflared peer, commonly 127.0.0.1 and ::1 on the same host. Do not copy only the public Cloudflare ranges.',
       afterTitle: 'Restart, verify this page, then enable the switches',
-      afterHint: 'Return here and check Trusted Proxy Status: the badge is Configured or Explicitly Disabled, the resolved client IP is your public address, and the enforcement identity is safe. Only then turn on the system-settings master switch, and finally enable enforcement on this page.',
+      afterHint: 'Return here and check Trusted Proxy Status: the badge is Configured or Explicitly Disabled, the resolved client IP is your public address (not a Cloudflare egress IP), and the enforcement identity is safe. Only then turn on the system-settings master switch, and finally enable enforcement on this page.',
       warningsTitle: 'Do not do this',
-      warningCloudflare: 'Do not put Cloudflare CIDRs, 0.0.0.0/0, ::/0, or * in the trusted proxy list. Cloudflare does not connect to this process directly.',
+      warningCloudflare: 'Do not put Cloudflare CIDRs, 0.0.0.0/0, ::/0, or * in the application trusted-proxy list. Cloudflare does not connect to this process; official CIDRs belong only in Nginx set_real_ip_from.',
       warningEnv: 'Do not set both the yaml file and SERVER_TRUSTED_PROXIES. If the environment variable exists, even empty, it replaces the file.',
       warningLegacy: 'The legacy forwarded-header compatibility switch does not control global IP enforcement. The global policy uses only server.trusted_proxies.',
-      warningWizard: 'Do not rerun the setup wizard to rewrite the config file. It will drop trusted_proxies.'
+      warningWizard: 'Do not rerun the setup wizard to rewrite the config file. It will drop trusted_proxies.',
     }
   }
 }

--- a/frontend/src/i18n/locales/zh/admin/ipAccessControl.ts
+++ b/frontend/src/i18n/locales/zh/admin/ipAccessControl.ts
@@ -143,15 +143,20 @@ export default {
       standaloneStep1: '写入与官方二进制相同的 server.trusted_proxies。',
       standaloneStep2: '停掉旧进程再启动新进程。只刷新网页不会加载这项。',
       proxyTitle: '反代必须清洗转发头',
-      proxyHint: '应用只接受直接可信代理送来的一个地址。不要用 $proxy_add_x_forwarded_for。',
+      proxyHint: '应用只接受直接可信代理送来的一个地址。不要用 $proxy_add_x_forwarded_for。只改转发头、不配 Real IP 时，当前客户端 IP 会变成 Cloudflare 出口（例如 162.158.*、172.64–172.71）。',
+      proxyCloudflareHint: 'Cloudflare 橙云必须先确认 nginx -V 含 --with-http_realip_module，再在 Nginx 的 http 块启用 Real IP，并用官方 CIDR 写 set_real_ip_from。只写注释不算配置。上线前再核对 https://www.cloudflare.com/ips-v4 和 https://www.cloudflare.com/ips-v6。',
+      proxyCloudflareHttp: 'underscores_in_headers on;\n\nreal_ip_header CF-Connecting-IP;\nreal_ip_recursive on;\n\nset_real_ip_from 173.245.48.0/20;\nset_real_ip_from 103.21.244.0/22;\nset_real_ip_from 103.22.200.0/22;\nset_real_ip_from 103.31.4.0/22;\nset_real_ip_from 141.101.64.0/18;\nset_real_ip_from 108.162.192.0/18;\nset_real_ip_from 190.93.240.0/20;\nset_real_ip_from 188.114.96.0/20;\nset_real_ip_from 197.234.240.0/22;\nset_real_ip_from 198.41.128.0/17;\nset_real_ip_from 162.158.0.0/15;\nset_real_ip_from 104.16.0.0/13;\nset_real_ip_from 104.24.0.0/14;\nset_real_ip_from 172.64.0.0/13;\nset_real_ip_from 131.0.72.0/22;\n\nset_real_ip_from 2400:cb00::/32;\nset_real_ip_from 2606:4700::/32;\nset_real_ip_from 2803:f800::/32;\nset_real_ip_from 2405:b500::/32;\nset_real_ip_from 2405:8100::/32;\nset_real_ip_from 2a06:98c0::/29;\nset_real_ip_from 2c0f:f248::/32;',
+      proxyHeaderHint: 'Real IP 生效后，$remote_addr 才是用户公网 IP。所有 proxy_pass 路由用覆盖式转发头，不要追加：',
       proxyNginx: 'proxy_set_header X-Real-IP $remote_addr;\nproxy_set_header X-Forwarded-For $remote_addr;\nproxy_set_header CF-Connecting-IP "";',
+      proxyVerify: '改完执行 nginx -t 并 reload。用 nginx -T | grep -E \'real_ip_header|set_real_ip_from\' 确认 http 块里是真实指令。回到本页后，当前客户端 IP 必须是你的公网地址，不能是 162.158.* 或 172.64–172.71。',
+      proxyTunnelHint: '若走 Cloudflare Tunnel，公网 CF CIDR 不会直连 Nginx。set_real_ip_from 应填写 cloudflared 的实际直连地址，本机常见 127.0.0.1 和 ::1，不要只抄公网 CF 段。',
       afterTitle: '重启后再验收、再开开关',
-      afterHint: '回到本页看「可信代理状态」：徽章为已配置或显式禁用，当前解析 IP 是你的公网地址，封禁身份可安全使用。达标后再开系统设置总开关，最后开本页拦截。',
+      afterHint: '回到本页看「可信代理状态」：徽章为已配置或显式禁用，当前解析 IP 是你的公网地址（不是 Cloudflare 出口），封禁身份可安全使用。达标后再开系统设置总开关，最后开本页拦截。',
       warningsTitle: '不要做这些事',
-      warningCloudflare: '不要把 Cloudflare CIDR、0.0.0.0/0、::/0 或 * 写入可信代理。Cloudflare 不直连本进程。',
+      warningCloudflare: '不要把 Cloudflare CIDR、0.0.0.0/0、::/0 或 * 写入应用的可信代理。Cloudflare 不直连本进程；官方 CIDR 只写在 Nginx 的 set_real_ip_from。',
       warningEnv: '不要同时写 yaml 和 SERVER_TRUSTED_PROXIES。环境变量一旦存在（包括空值）会覆盖文件。',
       warningLegacy: '系统设置里的「旧转发头兼容」不管全局封禁。全局策略只走 server.trusted_proxies。',
-      warningWizard: '不要再跑设置向导覆盖配置文件，trusted_proxies 会被抹掉。'
+      warningWizard: '不要再跑设置向导覆盖配置文件，trusted_proxies 会被抹掉。',
     }
   }
 }

--- a/frontend/src/views/admin/IPAccessControlView.vue
+++ b/frontend/src/views/admin/IPAccessControlView.vue
@@ -251,7 +251,12 @@
             <div class="mt-5 space-y-2 text-sm text-gray-600 dark:text-gray-300">
               <h3 class="font-semibold text-gray-900 dark:text-white">{{ t('admin.ipAccessControl.deployGuide.proxyTitle') }}</h3>
               <p>{{ t('admin.ipAccessControl.deployGuide.proxyHint') }}</p>
+              <p>{{ t('admin.ipAccessControl.deployGuide.proxyCloudflareHint') }}</p>
+              <pre class="overflow-x-auto rounded bg-gray-100 px-3 py-2 text-xs text-gray-800 dark:bg-dark-700 dark:text-gray-200">{{ t('admin.ipAccessControl.deployGuide.proxyCloudflareHttp') }}</pre>
+              <p>{{ t('admin.ipAccessControl.deployGuide.proxyHeaderHint') }}</p>
               <pre class="overflow-x-auto rounded bg-gray-100 px-3 py-2 text-xs text-gray-800 dark:bg-dark-700 dark:text-gray-200">{{ t('admin.ipAccessControl.deployGuide.proxyNginx') }}</pre>
+              <p>{{ t('admin.ipAccessControl.deployGuide.proxyVerify') }}</p>
+              <p>{{ t('admin.ipAccessControl.deployGuide.proxyTunnelHint') }}</p>
             </div>
             <div class="mt-5 rounded-lg bg-gray-50 p-3 text-sm text-gray-700 dark:bg-dark-700 dark:text-gray-300">
               <p class="font-medium">{{ t('admin.ipAccessControl.deployGuide.afterTitle') }}</p>

--- a/frontend/src/views/admin/__tests__/IPAccessControlView.spec.ts
+++ b/frontend/src/views/admin/__tests__/IPAccessControlView.spec.ts
@@ -221,6 +221,44 @@ describe('IPAccessControlView', () => {
     wrapper.unmount()
   })
 
+  it('shows Cloudflare Real IP steps in the deploy guide', async () => {
+    const host = document.createElement('div')
+    document.body.appendChild(host)
+    const wrapper = mount(IPAccessControlView, {
+      attachTo: host,
+      global: {
+        stubs: {
+          AppLayout: AppLayoutStub,
+          DataTable: DataTableStub,
+          Pagination: true,
+          Toggle: true,
+          Select: true,
+          Icon: true,
+          BaseDialog: BaseDialogStub,
+          ConfirmDialog: true,
+          TotpStepUpDialog: true,
+          RouterLink: true,
+        },
+      },
+    })
+    await flushPromises()
+
+    const guideLink = wrapper.findAll('button').find((button) => button.text() === 'admin.ipAccessControl.trustedProxy.guideLink')
+    expect(guideLink).toBeTruthy()
+    await guideLink!.trigger('click')
+    await flushPromises()
+
+    const bodyText = document.body.textContent ?? ''
+    expect(bodyText).toContain('admin.ipAccessControl.deployGuide.proxyCloudflareHint')
+    expect(bodyText).toContain('admin.ipAccessControl.deployGuide.proxyCloudflareHttp')
+    expect(bodyText).toContain('admin.ipAccessControl.deployGuide.proxyHeaderHint')
+    expect(bodyText).toContain('admin.ipAccessControl.deployGuide.proxyNginx')
+    expect(bodyText).toContain('admin.ipAccessControl.deployGuide.proxyVerify')
+    expect(bodyText).toContain('admin.ipAccessControl.deployGuide.proxyTunnelHint')
+    wrapper.unmount()
+    host.remove()
+  })
+
   it('renders safely when an older server returns null collection fields', async () => {
     getTrustedProxyStatus.mockResolvedValue({
       ...defaultProxyStatus,

--- a/skills/push-cli/scripts/push_cli.py
+++ b/skills/push-cli/scripts/push_cli.py
@@ -699,7 +699,7 @@ def open_pull_requests(
             "--base",
             default_branch,
             "--json",
-            "number,url,isDraft,headRefOid,baseRefOid,body",
+            "number,url,isDraft,headRefOid,body",
         ]
     )
     try:
@@ -708,6 +708,24 @@ def open_pull_requests(
         raise PushCliError("gh pr list returned invalid JSON") from error
     if not isinstance(prs, list) or any(not isinstance(pr, dict) for pr in prs):
         raise PushCliError("gh pr list returned an unexpected JSON value")
+    for pr in prs:
+        number = pr.get("number")
+        if not isinstance(number, int):
+            raise PushCliError("gh pr list returned a pull request without a number")
+        base_oid = capture(
+            [
+                "gh",
+                "api",
+                f"repos/{repository}/pulls/{number}",
+                "--jq",
+                ".base.sha",
+            ]
+        )
+        if not re.fullmatch(r"[0-9a-f]{40}", base_oid):
+            raise PushCliError(
+                f"GitHub returned an invalid base commit for pull request #{number}"
+            )
+        pr["baseRefOid"] = base_oid
     return prs
 
 

--- a/skills/push-cli/scripts/push_cli.py
+++ b/skills/push-cli/scripts/push_cli.py
@@ -525,7 +525,14 @@ def run_local_checks(
         ),
         (
             "Frontend tests",
-            ["pnpm", "--dir", "frontend", "run", "test:run"],
+            [
+                "pnpm",
+                "--dir",
+                "frontend",
+                "run",
+                "test:run",
+                "--maxWorkers=4",
+            ],
             ROOT,
         ),
         (

--- a/skills/push-cli/tests/test_push_cli.py
+++ b/skills/push-cli/tests/test_push_cli.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import argparse
 import importlib.util
+import json
 import subprocess
 import sys
 import unittest
@@ -530,6 +531,47 @@ class BranchAndProofTest(unittest.TestCase):
         ):
             with self.assertRaisesRegex(push_cli.PushCliError, "does not contain"):
                 push_cli.require_latest_base("origin", "main")
+
+
+class PullRequestQueryTest(unittest.TestCase):
+    def test_hydrates_base_oid_without_pr_list_base_ref_oid(self) -> None:
+        base_oid = "a" * 40
+        listing = json.dumps(
+            [
+                {
+                    "number": 22,
+                    "url": "https://github.com/LuckyKuang/sub2api-plus/pull/22",
+                    "isDraft": False,
+                    "headRefOid": "b" * 40,
+                    "body": "Summary",
+                }
+            ]
+        )
+        with mock.patch.object(
+            push_cli,
+            "capture",
+            side_effect=[listing, base_oid],
+        ) as capture:
+            prs = push_cli.open_pull_requests(
+                "LuckyKuang/sub2api-plus",
+                "feature",
+                "main",
+            )
+
+        self.assertEqual(base_oid, prs[0]["baseRefOid"])
+        list_command = capture.call_args_list[0].args[0]
+        self.assertIn("number,url,isDraft,headRefOid,body", list_command)
+        self.assertNotIn("baseRefOid", list_command)
+        self.assertEqual(
+            [
+                "gh",
+                "api",
+                "repos/LuckyKuang/sub2api-plus/pulls/22",
+                "--jq",
+                ".base.sha",
+            ],
+            capture.call_args_list[1].args[0],
+        )
 
 
 class ValidationLaunchTest(unittest.TestCase):

--- a/skills/push-cli/tests/test_push_cli.py
+++ b/skills/push-cli/tests/test_push_cli.py
@@ -498,6 +498,31 @@ class LocalChecksTest(unittest.TestCase):
         names = [call.args[0] for call in run_step.call_args_list]
         self.assertIn("Apple Container lifecycle test", names)
 
+    def test_frontend_tests_respect_validation_container_cpu_budget(self) -> None:
+        git_miss = subprocess.CompletedProcess(["git"], 1, "")
+        with (
+            mock.patch.object(push_cli, "ROOT", Path("/repo")),
+            mock.patch.object(push_cli, "run_command", return_value=git_miss),
+            mock.patch.object(push_cli, "run_step") as run_step,
+            mock.patch.object(push_cli, "run_frontend_security_check"),
+        ):
+            push_cli.run_local_checks("origin", "feature", push_cli.Runtime("docker"))
+
+        frontend_test = next(
+            call for call in run_step.call_args_list if call.args[0] == "Frontend tests"
+        )
+        self.assertEqual(
+            [
+                "pnpm",
+                "--dir",
+                "frontend",
+                "run",
+                "test:run",
+                "--maxWorkers=4",
+            ],
+            frontend_test.args[1],
+        )
+
 
 class DeclaredToolchainsTest(unittest.TestCase):
     def test_reads_repository_pins(self) -> None:


### PR DESCRIPTION
## Summary
- Add Nginx Real IP and official Cloudflare CIDR steps to the in-app IP access deploy guide.
- Document overwrite-only forwarded headers and Tunnel peer trust, so global IP blocking can resolve the real client instead of a Cloudflare egress address.

## Test plan
- [ ] Open Admin → IP Access Control → View setup steps.
- [ ] Confirm the Cloudflare Real IP `http` block and overwrite header snippets are shown in both zh and en.
- [ ] `pnpm test:run src/views/admin/__tests__/IPAccessControlView.spec.ts`