### PR TITLE
test: make nil guards explicit for staticcheck

### DIFF
--- a/backend/internal/handler/admin/payment_handler_test.go
+++ b/backend/internal/handler/admin/payment_handler_test.go
@@ -34,6 +34,7 @@ func TestSanitizeAdminPaymentOrderForResponseAddsCurrency(t *testing.T) {
 	got := sanitizeAdminPaymentOrderForResponse(order)
 	if got == nil {
 		t.Fatal("expected sanitized order")
+		return
 	}
 	if got.Currency != "USD" {
 		t.Fatalf("expected currency USD, got %q", got.Currency)

--- a/backend/internal/pkg/proxyurl/parse_test.go
+++ b/backend/internal/pkg/proxyurl/parse_test.go
@@ -41,6 +41,7 @@ func TestParse_有效HTTP代理(t *testing.T) {
 	}
 	if parsed == nil {
 		t.Fatal("parsed 不应为 nil")
+		return
 	}
 	if parsed.Host != "proxy.example.com:8080" {
 		t.Errorf("Host 不匹配: got %q", parsed.Host)

--- a/backend/internal/service/account_usage_service_test.go
+++ b/backend/internal/service/account_usage_service_test.go
@@ -268,6 +268,7 @@ func TestBuildCodexUsageProgressFromExtra_IgnoresDurationOverflowingLegacyReset(
 	progress := buildCodexUsageProgressFromExtra(extra, "5h", now)
 	if progress == nil {
 		t.Fatal("expected non-nil progress")
+		return
 	}
 	if progress.ResetsAt != nil {
 		t.Fatalf("expected no reset timestamp from overflowing legacy value, got %v", *progress.ResetsAt)


### PR DESCRIPTION
## Summary

Submit `fix/staticcheck-test-nil-guards` after the repository local-validation gate.

## Validation

- Platform-container validation matrix passed.

<!-- sub2api-submit-pr: {"base":"469666c2e022122de3f07de967748abf14e7b897","head":"ea565d2a36304e3ec0d7552cdd9fc9ddb493ddfe"} -->
