### PR TITLE
ci: avoid stale golangci-lint cache

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -110,6 +110,9 @@ jobs:
           version: ${{ steps.tool-versions.outputs.golangci_lint }}
           args: --timeout=30m
           working-directory: backend
+          # Cached analyzer results can survive linter upgrades and differ by
+          # ref scope, producing stale findings between push and PR runs.
+          skip-cache: true
 
   goreleaser-config:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Submit `fix/staticcheck-nil-guards-complete` after the repository local-validation gate.

## Validation

- Platform-container validation matrix passed.

<!-- sub2api-submit-pr: {"base":"720643e755d232f28775d70b971f0d0ef7f3b678","head":"85aeab671f52ee03cd1e0c57af134694c02fc829"} -->
