### PR TITLE
fix: keep OpenAI session routing consistent

### DIFF
--- a/backend/internal/handler/openai_gateway_handler.go
+++ b/backend/internal/handler/openai_gateway_handler.go
@@ -47,8 +47,14 @@ type OpenAIGatewayHandler struct {
 }
 
 type openAIWSTurnChannelMappingSnapshot struct {
-	turn    int
-	mapping service.ChannelMappingResult
+	turn           int
+	requestedModel string
+	mapping        service.ChannelMappingResult
+}
+
+type openAIWSTurnCapabilitySnapshot struct {
+	turn       int
+	capability service.OpenAIEndpointCapability
 }
 
 var errOpenAIWSUnsupportedModelSwitch = errors.New("selected account does not support websocket model switch")
@@ -1534,12 +1540,11 @@ const (
 // 由 BeforeTurn 在每个 turn 开始时冻结，AfterTurn 的用量提交读取它；turn 在
 // 连接内串行推进，互斥锁只为跨用量提交 goroutine 的读取安全。
 //
-// 零值语义（重要）：ws_v2 passthrough ingress 只实现了 AfterTurn，没有任何
-// turn 起始回调，BeforeTurn 永远不会被调用。此时本值保持零，RecordUsage 经
-// openAIUsagePricingAt 回退到记录时刻——与引入分组利润控制前的基线一致。
-// 绝不能用建连时刻初始化：那会把透传连接的所有 turn 钉死在建连时的高峰因子，
-// 客户端只要峰前一分钟建连并保活，整条连接就能全程按谷价结算，正是利润控制
-// 想堵的漏洞。透传 ingress 目前不做 turn 级利润复核，只有建连时的准入门。
+// 所有 ingress 模式（包括 ws_v2 passthrough）都必须在每个 response.create 前
+// 调用 BeforeTurn；本值由该回调按 turn 冻结。零值仅用于尚未开始 turn 的连接，
+// RecordUsage 会防御性回退到记录时刻。绝不能用建连时刻初始化：那会把长连接
+// 的所有 turn 钉死在建连时的高峰因子，客户端只要峰前建连并保活即可长期按
+// 旧时刻计费，也会绕过每 turn 的账号硬资格复核。
 type openAIWSTurnPricing struct {
 	mu sync.Mutex
 	at time.Time
@@ -2211,7 +2216,13 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 		// Passthrough rejects overlapping response.create frames, so one immutable
 		// turn-tagged slot preserves the exact mapping used for the in-flight request.
 		var turnChannelMapping atomic.Pointer[openAIWSTurnChannelMappingSnapshot]
-		turnChannelMapping.Store(&openAIWSTurnChannelMappingSnapshot{turn: 1, mapping: channelMappingWS})
+		turnChannelMapping.Store(&openAIWSTurnChannelMappingSnapshot{
+			turn:           1,
+			requestedModel: reqModel,
+			mapping:        channelMappingWS,
+		})
+		var turnCapability atomic.Pointer[openAIWSTurnCapabilitySnapshot]
+		turnCapability.Store(&openAIWSTurnCapabilitySnapshot{turn: 1, capability: requiredCapability})
 		// turn 级定价：BeforeTurn 重新冻结 pricingAt 并按最新门复核当前账号，
 		// AfterTurn 的计费读取所属 turn 的时刻。零值起步的语义见
 		// openAIWSTurnPricing 的注释——绝不能用建连时刻初始化。
@@ -2240,6 +2251,16 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 					writeSecurityAuditWSError(ctx, wsConn, decision)
 					return service.NewOpenAIWSClientCloseError(securityAuditWSCloseStatus(decision), securityAuditWSCloseReason(decision), nil)
 				}
+				turnRequiredCapability := service.OpenAIEndpointCapabilityChatCompletions
+				if service.IsExplicitImageGenerationIntent("/v1/responses", model, payload) {
+					if !service.GroupAllowsImageGeneration(apiKey.Group) {
+						return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, service.ImageGenerationPermissionMessage(), nil)
+					}
+					if requestPlatform == service.PlatformOpenAI {
+						turnRequiredCapability = service.OpenAIEndpointCapabilityResponses
+					}
+				}
+				turnCapability.Store(&openAIWSTurnCapabilitySnapshot{turn: turn, capability: turnRequiredCapability})
 				return nil
 			},
 			MapRequestModel: func(turn int, originalModel string) (string, error) {
@@ -2255,7 +2276,11 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				if turn > 1 && !mappedModelUnchanged && !account.IsModelSupported(model) && !account.IsModelSupported(mapping.MappedModel) {
 					return "", newOpenAIWSUnsupportedModelSwitchError(mapping.MappedModel)
 				}
-				turnChannelMapping.Store(&openAIWSTurnChannelMappingSnapshot{turn: turn, mapping: mapping})
+				turnChannelMapping.Store(&openAIWSTurnChannelMappingSnapshot{
+					turn:           turn,
+					requestedModel: model,
+					mapping:        mapping,
+				})
 				return mapping.MappedModel, nil
 			},
 			BeforeTurn: func(turn int) error {
@@ -2266,11 +2291,59 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				if cyberBlockedThisConn {
 					return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, cyberSessionBlockedClientMsg, nil)
 				}
-				// 长连接跨峰谷/倍率刷新防护：每个 turn 按当前时刻重装门并复核
-				// 当前账号，越线即要求客户端重连重选（连接绑定单一上游账号，
-				// 无法中途换号）。本 turn 的准入与计费共用同一 pricingAt。
+				// The first turn was checked once before account selection. Recheck each
+				// later turn so a long-lived connection cannot bypass a balance,
+				// subscription, platform-quota, API-key-limit, or RPM decision that a
+				// fresh HTTP request would observe.
+				if turn > 1 {
+					if err := h.billingCacheService.CheckBillingEligibility(ctx, apiKey.User, apiKey, apiKey.Group, subscription, service.QuotaPlatform(ctx, apiKey)); err != nil {
+						reqLog.Info("openai.websocket_turn_billing_eligibility_check_failed",
+							zap.Int("turn", turn),
+							zap.Error(err))
+						return service.NewOpenAIWSClientCloseError(coderws.StatusPolicyViolation, "billing check failed", err)
+					}
+				}
+				turnModel := reqModel
+				if snapshot := turnChannelMapping.Load(); snapshot != nil && snapshot.turn == turn {
+					if model := strings.TrimSpace(snapshot.requestedModel); model != "" {
+						turnModel = model
+					}
+				}
+				turnRequiredCapability := requiredCapability
+				if snapshot := turnCapability.Load(); snapshot != nil && snapshot.turn == turn {
+					turnRequiredCapability = snapshot.capability
+				}
+				// 长连接不能在 turn 间安全更换持有凭据的上游账号。每轮从 DB
+				// 重载账号并执行与新 HTTP 请求一致的硬资格检查，使切组、禁用/
+				// 暂停、配额、模型能力和传输模式变更都在写入上游前生效。
+				latestAccount, err := h.gatewayService.RevalidateOpenAIAccountForWebSocketTurn(
+					ctx,
+					account,
+					apiKey.GroupID,
+					requestPlatform,
+					turnModel,
+					requiredTransport,
+					turnRequiredCapability,
+				)
+				if err != nil {
+					reqLog.Warn("openai.websocket_turn_account_revalidation_failed",
+						zap.Int("turn", turn),
+						zap.Int64("account_id", account.ID),
+						zap.Error(err))
+					return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account eligibility could not be revalidated, please reconnect", err)
+				}
+				if latestAccount == nil {
+					reqLog.Info("openai.websocket_turn_account_ineligible",
+						zap.Int("turn", turn),
+						zap.Int64("account_id", account.ID),
+						zap.String("model", turnModel))
+					return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account is no longer eligible for this connection, please reconnect", nil)
+				}
+				// 每个 turn 按当前时刻重装利润门并复核当前账号，越线同样要求
+				// 重连重选（连接绑定单一上游账号，无法中途换号）。本 turn 的
+				// 准入与计费共用同一 pricingAt。
 				turnCtx, turnAt := h.gatewayService.WithOpenAITurnPricingContext(ctx, apiKey.GroupID)
-				if _, vetoed, reason := h.gatewayService.ProfitControlVetoLatest(turnCtx, account); vetoed {
+				if _, vetoed, reason := h.gatewayService.ProfitControlVetoLatest(turnCtx, latestAccount); vetoed {
 					reqLog.Info("openai.websocket_turn_profit_vetoed",
 						zap.Int("turn", turn),
 						zap.Int64("account_id", account.ID),
@@ -2278,6 +2351,7 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 					return service.NewOpenAIWSClientCloseError(coderws.StatusTryAgainLater, "account is no longer eligible for this connection, please reconnect", nil)
 				}
 				turnPricing.freeze(turnAt)
+				accountMaxConcurrency = latestAccount.Concurrency
 				if turn == 1 {
 					return nil
 				}
@@ -2316,18 +2390,21 @@ func (h *OpenAIGatewayHandler) ResponsesWebSocket(c *gin.Context) {
 				releaseTurnSlots()
 				turnRequestedModel := reqModel
 				turnUpstreamModel := ""
-				if result != nil && turn > 1 {
-					if model := strings.TrimSpace(result.Model); model != "" {
-						turnRequestedModel = model
-					}
-				}
 				if result != nil {
 					turnUpstreamModel = strings.TrimSpace(result.UpstreamModel)
 				}
 				var turnMapping service.ChannelMappingResult
 				if snapshot := turnChannelMapping.Load(); snapshot != nil && snapshot.turn == turn {
+					if model := strings.TrimSpace(snapshot.requestedModel); model != "" {
+						turnRequestedModel = model
+					}
 					turnMapping = snapshot.mapping
 				} else {
+					if result != nil && turn > 1 {
+						if model := strings.TrimSpace(result.Model); model != "" {
+							turnRequestedModel = model
+						}
+					}
 					turnMapping, _ = h.gatewayService.ResolveChannelMappingAndRestrict(ctx, apiKey.GroupID, turnRequestedModel)
 				}
 				if turnUpstreamModel == "" {

--- a/backend/internal/handler/openai_gateway_handler_test.go
+++ b/backend/internal/handler/openai_gateway_handler_test.go
@@ -1832,6 +1832,18 @@ type openAIWSFailoverHandlerAccountRepoStub struct {
 	rateLimitedIDs []int64
 }
 
+type openAIWSTurnBillingCacheStub struct {
+	service.BillingCache
+	balanceChecks atomic.Int32
+}
+
+func (s *openAIWSTurnBillingCacheStub) GetUserBalance(context.Context, int64) (float64, error) {
+	if s.balanceChecks.Add(1) == 1 {
+		return 1, nil
+	}
+	return 0, nil
+}
+
 type openAIHTTPPassthroughFailoverUpstream struct {
 	service.HTTPUpstream
 	mu         sync.Mutex
@@ -1918,6 +1930,154 @@ func (u *openAIHTTPPassthroughSSERateLimitUpstream) calls() []int64 {
 	u.mu.Lock()
 	defer u.mu.Unlock()
 	return append([]int64(nil), u.accountIDs...)
+}
+
+func TestOpenAIResponsesWebSocket_RechecksBillingBeforePassthroughFollowUpTurn(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	upstreamWrites := make(chan []byte, 2)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		conn, err := coderws.Accept(w, r, &coderws.AcceptOptions{CompressionMode: coderws.CompressionContextTakeover})
+		if err != nil {
+			return
+		}
+		defer func() { _ = conn.CloseNow() }()
+
+		readCtx, cancelRead := context.WithTimeout(r.Context(), 3*time.Second)
+		_, first, readErr := conn.Read(readCtx)
+		cancelRead()
+		if readErr != nil {
+			return
+		}
+		upstreamWrites <- first
+
+		writeCtx, cancelWrite := context.WithTimeout(r.Context(), 3*time.Second)
+		_ = conn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.completed","response":{"id":"resp_billing_first","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`))
+		cancelWrite()
+
+		readCtx, cancelRead = context.WithTimeout(r.Context(), 2*time.Second)
+		_, second, readErr := conn.Read(readCtx)
+		cancelRead()
+		if readErr == nil {
+			upstreamWrites <- second
+		}
+	}))
+	defer upstream.Close()
+
+	groupID := int64(4210)
+	account := service.Account{
+		ID:          9920,
+		Name:        "openai-ws-turn-billing",
+		Platform:    service.PlatformOpenAI,
+		Type:        service.AccountTypeAPIKey,
+		Status:      service.StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		GroupIDs:    []int64{groupID},
+		Credentials: map[string]any{"api_key": "sk-test", "base_url": upstream.URL},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+			"openai_apikey_responses_websockets_v2_mode":    service.OpenAIWSIngressModePassthrough,
+		},
+	}
+
+	cfg := &config.Config{}
+	cfg.RunMode = config.RunModeStandard
+	cfg.Default.RateMultiplier = 1
+	cfg.Security.URLAllowlist.Enabled = false
+	cfg.Security.URLAllowlist.AllowInsecureHTTP = true
+	cfg.Gateway.OpenAIWS.Enabled = true
+	cfg.Gateway.OpenAIWS.APIKeyEnabled = true
+	cfg.Gateway.OpenAIWS.ResponsesWebsocketsV2 = true
+	cfg.Gateway.OpenAIWS.ModeRouterV2Enabled = true
+	cfg.Gateway.OpenAIWS.DialTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.ReadTimeoutSeconds = 3
+	cfg.Gateway.OpenAIWS.WriteTimeoutSeconds = 3
+
+	accountRepo := &openAIWSFailoverHandlerAccountRepoStub{accounts: []service.Account{account}}
+	billingCache := &openAIWSTurnBillingCacheStub{}
+	billingCacheSvc := service.NewBillingCacheService(billingCache, nil, nil, nil, nil, nil, cfg, nil)
+	t.Cleanup(billingCacheSvc.Stop)
+	rateLimitSvc := service.NewRateLimitService(accountRepo, nil, cfg, nil, nil)
+	gatewaySvc := service.NewOpenAIGatewayService(
+		accountRepo, nil, nil, nil, nil, nil, nil, cfg, nil, nil,
+		service.NewBillingService(cfg, nil), rateLimitSvc, billingCacheSvc, nil,
+		&service.DeferredService{}, nil, nil, nil, nil, nil, nil, nil,
+	)
+	concurrencyCache := &concurrencyCacheMock{
+		acquireUserSlotFn:    func(context.Context, int64, int, string) (bool, error) { return true, nil },
+		acquireAccountSlotFn: func(context.Context, int64, int, string) (bool, error) { return true, nil },
+	}
+	h := &OpenAIGatewayHandler{
+		gatewayService:      gatewaySvc,
+		billingCacheService: billingCacheSvc,
+		apiKeyService:       &service.APIKeyService{},
+		concurrencyHelper:   NewConcurrencyHelper(service.NewConcurrencyService(concurrencyCache), SSEPingFormatNone, time.Second),
+	}
+	attachDisabledIPAccessControlForWebSocketTest(h)
+
+	apiKey := &service.APIKey{
+		ID:      1810,
+		GroupID: &groupID,
+		User:    &service.User{ID: 1710, Status: service.StatusActive},
+		Group:   &service.Group{ID: groupID, Platform: service.PlatformOpenAI, Status: service.StatusActive},
+	}
+	router := gin.New()
+	router.Use(func(c *gin.Context) {
+		c.Set(string(middleware.ContextKeyAPIKey), apiKey)
+		c.Set(string(middleware.ContextKeyUser), middleware.AuthSubject{UserID: apiKey.User.ID, Concurrency: 1})
+		c.Next()
+	})
+	router.GET("/openai/v1/responses", h.ResponsesWebSocket)
+	handlerServer := httptest.NewServer(router)
+	defer handlerServer.Close()
+
+	dialCtx, cancelDial := context.WithTimeout(context.Background(), 3*time.Second)
+	clientConn, _, err := coderws.Dial(
+		dialCtx,
+		"ws"+strings.TrimPrefix(handlerServer.URL, "http")+"/openai/v1/responses",
+		&coderws.DialOptions{CompressionMode: coderws.CompressionContextTakeover},
+	)
+	cancelDial()
+	require.NoError(t, err)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","stream":false}`))
+	cancelWrite()
+	require.NoError(t, err)
+
+	readCtx, cancelRead := context.WithTimeout(context.Background(), 3*time.Second)
+	_, firstEvent, err := clientConn.Read(readCtx)
+	cancelRead()
+	require.NoError(t, err)
+	require.Equal(t, "response.completed", gjson.GetBytes(firstEvent, "type").String())
+
+	writeCtx, cancelWrite = context.WithTimeout(context.Background(), 3*time.Second)
+	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","previous_response_id":"resp_billing_first"}`))
+	cancelWrite()
+	require.NoError(t, err)
+
+	readCtx, cancelRead = context.WithTimeout(context.Background(), 3*time.Second)
+	_, _, err = clientConn.Read(readCtx)
+	cancelRead()
+	var closeErr coderws.CloseError
+	require.ErrorAs(t, err, &closeErr)
+	require.Equal(t, coderws.StatusPolicyViolation, closeErr.Code)
+	require.Equal(t, "billing check failed", closeErr.Reason)
+	require.Equal(t, int32(2), billingCache.balanceChecks.Load(), "billing must run once per accepted websocket turn")
+
+	select {
+	case first := <-upstreamWrites:
+		require.Equal(t, "response.create", gjson.GetBytes(first, "type").String())
+	case <-time.After(3 * time.Second):
+		t.Fatal("first websocket turn did not reach upstream")
+	}
+	select {
+	case second := <-upstreamWrites:
+		t.Fatalf("billing-rejected follow-up turn reached upstream: %s", second)
+	case <-time.After(200 * time.Millisecond):
+	}
 }
 
 func (s *openAIWSFailoverHandlerAccountRepoStub) ListSchedulableByPlatform(ctx context.Context, platform string) ([]service.Account, error) {

--- a/backend/internal/service/openai_account_scheduler.go
+++ b/backend/internal/service/openai_account_scheduler.go
@@ -381,8 +381,33 @@ func (s *defaultOpenAIAccountScheduler) Select(
 	}()
 
 	previousResponseID := strings.TrimSpace(req.PreviousResponseID)
+	sessionChecked := false
+	sessionStickyEscaped := false
+	// A movable continuation may follow a session route that another endpoint
+	// already migrated after an upstream failure. Consult that canonical route
+	// before the older response binding; the handler will remove the response ID
+	// when the selected account differs from its owner.
+	if !req.StickyWeighted && req.PreviousResponseCanMove {
+		sessionChecked = true
+		selection, escapedSticky, err := s.selectBySessionHash(ctx, req)
+		if err != nil {
+			return nil, decision, err
+		}
+		if selection != nil && selection.Account != nil {
+			decision.Layer = openAIAccountScheduleLayerSessionSticky
+			decision.StickySessionHit = true
+			decision.StickyPreviousHit = req.StickyPreviousAccountID > 0 && req.StickyPreviousAccountID == selection.Account.ID
+			decision.SelectedAccountID = selection.Account.ID
+			decision.SelectedAccountType = selection.Account.Type
+			return selection, decision, nil
+		}
+		if escapedSticky {
+			req.PreserveStickyBinding = true
+			sessionStickyEscaped = true
+		}
+	}
 	if previousResponseID != "" && normalizeOpenAICompatiblePlatform(req.Platform) == PlatformOpenAI &&
-		(!req.StickyWeighted || !req.PreviousResponseCanMove) {
+		(!req.StickyWeighted || !req.PreviousResponseCanMove) && !sessionStickyEscaped {
 		selection, err := s.service.selectAccountByPreviousResponseIDForCapability(
 			ctx,
 			req.GroupID,
@@ -415,7 +440,7 @@ func (s *defaultOpenAIAccountScheduler) Select(
 		}
 	}
 
-	if !req.StickyWeighted {
+	if !req.StickyWeighted && !sessionChecked {
 		selection, escapedSticky, err := s.selectBySessionHash(ctx, req)
 		if err != nil {
 			return nil, decision, err
@@ -736,8 +761,16 @@ func deriveOpenAISelectionSeed(req OpenAIAccountScheduleRequest) uint64 {
 		_, _ = hasher.Write([]byte{0})
 	}
 
-	writeValue(req.SessionHash)
-	writeValue(req.PreviousResponseID)
+	// A stable client session is the canonical cross-endpoint routing identity.
+	// previous_response_id exists only on Responses continuations, so mixing it
+	// into an already session-scoped seed would give Responses and Alpha Search
+	// different candidate orders. Keep it only as the fallback identity for
+	// callers that genuinely have no session signal.
+	if sessionHash := strings.TrimSpace(req.SessionHash); sessionHash != "" {
+		writeValue(sessionHash)
+	} else {
+		writeValue(req.PreviousResponseID)
+	}
 	writeValue(req.RequestedModel)
 	if req.GroupID != nil {
 		_, _ = hasher.Write([]byte(strconv.FormatInt(*req.GroupID, 10)))
@@ -1019,7 +1052,7 @@ func (s *defaultOpenAIAccountScheduler) buildOpenAISelectionOrder(
 		ranked := selectTopKOpenAICandidates(pool, groupTopK)
 		var primary []openAIAccountCandidateScore
 		if req.StickyWeighted {
-			for _, stickyID := range []int64{req.StickyPreviousAccountID, req.StickyAccountID} {
+			for _, stickyID := range []int64{req.StickyAccountID, req.StickyPreviousAccountID} {
 				if stickyID <= 0 {
 					continue
 				}
@@ -1226,7 +1259,7 @@ func (s *defaultOpenAIAccountScheduler) tryFallbackToWeightedSticky(
 	if !req.StickyWeighted {
 		return nil, nil
 	}
-	for _, accountID := range []int64{req.StickyPreviousAccountID, req.StickyAccountID} {
+	for _, accountID := range []int64{req.StickyAccountID, req.StickyPreviousAccountID} {
 		if accountID <= 0 {
 			continue
 		}
@@ -2149,7 +2182,8 @@ func (s *OpenAIGatewayService) selectAccountWithScheduler(
 			return selection, decision, err
 		}
 		if selection == nil || selection.Account == nil || strings.TrimSpace(previousResponseID) == "" ||
-			!selection.Account.IsOpenAIOAuthSessionSharingEnabled() {
+			!selection.Account.IsOpenAIOAuthSessionSharingEnabled() ||
+			(previousResponseCanMove && !decision.StickyPreviousHit) {
 			return selection, decision, nil
 		}
 		if err := s.validateOpenAISharedPreviousResponseAccountSelection(ctx, groupID, previousResponseID, selection.Account); err == nil {
@@ -2231,6 +2265,10 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 	}
 	platform = normalizeOpenAICompatiblePlatform(platform)
 	decision := OpenAIAccountScheduleDecision{}
+	stickyPreviousAccountID := int64(0)
+	if previousResponseCanMove && strings.TrimSpace(previousResponseID) != "" && platform == PlatformOpenAI {
+		stickyPreviousAccountID = s.ResolveAccountIDByPreviousResponseIDForScheduler(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact)
+	}
 	scheduler := s.getOpenAIAccountScheduler(ctx)
 	if scheduler == nil {
 		decision.Layer = openAIAccountScheduleLayerLoadBalance
@@ -2245,6 +2283,7 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 					return selection, decision, s.mapOpenAIOAuthSessionPolicySelectionError(ctx, groupID, platform, requestedModel, effectiveExcludedIDs, requiredTransport, requiredCapability, requiredImageCapability, requireCompact, nil)
 				}
 				if accountSupportsOpenAICapabilities(selection.Account, requiredCapability, requiredImageCapability) {
+					decision.StickyPreviousHit = stickyPreviousAccountID > 0 && stickyPreviousAccountID == selection.Account.ID
 					return selection, decision, nil
 				}
 				if selection.ReleaseFunc != nil {
@@ -2271,6 +2310,7 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 			}
 			if s.isOpenAIAccountTransportCompatible(selection.Account, requiredTransport) &&
 				accountSupportsOpenAICapabilities(selection.Account, requiredCapability, requiredImageCapability) {
+				decision.StickyPreviousHit = stickyPreviousAccountID > 0 && stickyPreviousAccountID == selection.Account.ID
 				return selection, decision, nil
 			}
 			if selection.ReleaseFunc != nil {
@@ -2301,11 +2341,6 @@ func (s *OpenAIGatewayService) selectAccountWithSchedulerOnce(
 	}
 	stickyWeighted := s.isOpenAIAdvancedSchedulerStickyWeightedEnabled(ctx)
 	subscriptionPriority := s.isOpenAIAdvancedSchedulerSubscriptionPriorityEnabled(ctx)
-	stickyPreviousAccountID := int64(0)
-	if stickyWeighted && previousResponseCanMove && strings.TrimSpace(previousResponseID) != "" && platform == PlatformOpenAI {
-		stickyPreviousAccountID = s.ResolveAccountIDByPreviousResponseIDForScheduler(ctx, groupID, previousResponseID, requestedModel, excludedIDs, requiredCapability, requireCompact)
-	}
-
 	selection, decision, err := scheduler.Select(ctx, OpenAIAccountScheduleRequest{
 		GroupID:                 groupID,
 		Platform:                platform,

--- a/backend/internal/service/openai_account_scheduler_test.go
+++ b/backend/internal/service/openai_account_scheduler_test.go
@@ -1320,6 +1320,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_EnabledUsesAdvancedPrev
 			Schedulable: true,
 			Concurrency: 1,
 			Priority:    5,
+			GroupIDs:    []int64{groupID},
 			Extra: map[string]any{
 				"openai_apikey_responses_websockets_v2_enabled": true,
 			},
@@ -2463,6 +2464,7 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_PreviousResponseSticky(
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 2,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
 		},
@@ -2506,6 +2508,350 @@ func TestOpenAIGatewayService_SelectAccountWithScheduler_PreviousResponseSticky(
 	require.Equal(t, account.ID, cache.sessionBindings["openai:session_hash_001"])
 	if selection.ReleaseFunc != nil {
 		selection.ReleaseFunc()
+	}
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_MovableContinuationUsesMigratedSessionRoute(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	defer resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(9010)
+	responseAccount := Account{
+		ID:          90101,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+		GroupIDs:    []int64{groupID},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+		},
+	}
+	migratedAccount := Account{
+		ID:          90102,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    50,
+		GroupIDs:    []int64{groupID},
+	}
+	newService := func() (*OpenAIGatewayService, OpenAIWSStateStore) {
+		cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{
+			"openai:session_migrated_cross_endpoint": migratedAccount.ID,
+		}}
+		svc := &OpenAIGatewayService{
+			accountRepo:        schedulerTestOpenAIAccountRepo{accounts: []Account{responseAccount, migratedAccount}},
+			cache:              cache,
+			cfg:                newSchedulerTestOpenAIWSV2Config(),
+			rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+			concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+		}
+		store := svc.getOpenAIWSStateStore()
+		require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_before_cross_endpoint_failover", responseAccount.ID, time.Hour))
+		return svc, store
+	}
+
+	t.Run("movable request follows migrated session", func(t *testing.T) {
+		svc, _ := newService()
+		selection, decision, err := svc.SelectAccountWithSchedulerForCapability(
+			ctx,
+			&groupID,
+			"resp_before_cross_endpoint_failover",
+			"session_migrated_cross_endpoint",
+			"gpt-5.1",
+			nil,
+			OpenAIUpstreamTransportAny,
+			OpenAIEndpointCapabilityChatCompletions,
+			false,
+			true,
+			true,
+			PlatformOpenAI,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, selection)
+		require.Equal(t, migratedAccount.ID, selection.Account.ID)
+		require.Equal(t, openAIAccountScheduleLayerSessionSticky, decision.Layer)
+		require.True(t, decision.StickySessionHit)
+		require.False(t, decision.StickyPreviousHit)
+		if selection.ReleaseFunc != nil {
+			selection.ReleaseFunc()
+		}
+	})
+
+	t.Run("non-movable request stays on response owner", func(t *testing.T) {
+		svc, _ := newService()
+		selection, decision, err := svc.SelectAccountWithSchedulerForCapability(
+			ctx,
+			&groupID,
+			"resp_before_cross_endpoint_failover",
+			"session_migrated_cross_endpoint",
+			"gpt-5.1",
+			nil,
+			OpenAIUpstreamTransportAny,
+			OpenAIEndpointCapabilityChatCompletions,
+			false,
+			false,
+			true,
+			PlatformOpenAI,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, selection)
+		require.Equal(t, responseAccount.ID, selection.Account.ID)
+		require.Equal(t, openAIAccountScheduleLayerPreviousResponse, decision.Layer)
+		require.True(t, decision.StickyPreviousHit)
+		if selection.ReleaseFunc != nil {
+			selection.ReleaseFunc()
+		}
+	})
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_MovableContinuationHonorsSessionStickyEscape(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	defer resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(9012)
+	stickyAccount := Account{
+		ID:          90121,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+		GroupIDs:    []int64{groupID},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+		},
+	}
+	replacementAccount := Account{
+		ID:          90122,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    1,
+		GroupIDs:    []int64{groupID},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+		},
+	}
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{
+		"openai:session_escape_with_previous": stickyAccount.ID,
+	}}
+	cfg := newSchedulerTestOpenAIWSV2Config()
+	cfg.Gateway.OpenAIScheduler.StickyEscapeEnabled = true
+	cfg.Gateway.OpenAIScheduler.StickyEscapeTTFTMs = 15000
+	cfg.Gateway.OpenAIScheduler.StickyEscapeErrorRate = 0.5
+	svc := &OpenAIGatewayService{
+		accountRepo:      schedulerTestOpenAIAccountRepo{accounts: []Account{stickyAccount, replacementAccount}},
+		cache:            cache,
+		cfg:              cfg,
+		rateLimitService: newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{acquireResults: map[int64]bool{
+			stickyAccount.ID:      false,
+			replacementAccount.ID: true,
+		}}),
+		openaiAccountStats: newOpenAIAccountRuntimeStats(),
+	}
+	store := svc.getOpenAIWSStateStore()
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_escape_with_previous", stickyAccount.ID, time.Hour))
+
+	slowTTFT := 20000
+	for i := 0; i < 3; i++ {
+		svc.openaiAccountStats.report(stickyAccount.ID, true, &slowTTFT)
+	}
+
+	selection, decision, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"resp_escape_with_previous",
+		"session_escape_with_previous",
+		"gpt-5.1",
+		nil,
+		OpenAIUpstreamTransportResponsesWebsocketV2,
+		OpenAIEndpointCapabilityChatCompletions,
+		false,
+		true,
+		true,
+		PlatformOpenAI,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, replacementAccount.ID, selection.Account.ID, "previous_response_id must not cancel a session sticky escape")
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+	require.False(t, decision.StickyPreviousHit)
+	require.False(t, decision.StickySessionHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+
+	boundSessionAccountID, getErr := cache.GetSessionAccountID(ctx, groupID, "openai:session_escape_with_previous")
+	require.NoError(t, getErr)
+	require.Equal(t, stickyAccount.ID, boundSessionAccountID, "a soft escape must preserve the canonical sticky binding")
+	boundResponseAccountID, getErr := store.GetResponseAccount(ctx, groupID, "resp_escape_with_previous")
+	require.NoError(t, getErr)
+	require.Equal(t, stickyAccount.ID, boundResponseAccountID, "a soft escape must not rewrite the old response owner")
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_GroupRemovalMigratesWholeSession(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	defer resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := context.Background()
+	groupID := int64(9015)
+	otherGroupID := int64(9016)
+	removedAccount := Account{
+		ID:          90151,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    100,
+		GroupIDs:    []int64{otherGroupID},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+		},
+	}
+	replacementAccount := Account{
+		ID:          90152,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Priority:    0,
+		GroupIDs:    []int64{groupID},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+		},
+	}
+	cache := &schedulerTestGatewayCache{sessionBindings: map[string]int64{
+		"openai:session_group_removed": removedAccount.ID,
+	}}
+	svc := &OpenAIGatewayService{
+		accountRepo: schedulerGroupAwareOpenAIAccountRepo{schedulerTestOpenAIAccountRepo{
+			accounts: []Account{removedAccount, replacementAccount},
+		}},
+		cache:              cache,
+		cfg:                newSchedulerTestOpenAIWSV2Config(),
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+	store := svc.getOpenAIWSStateStore()
+	require.NoError(t, store.BindResponseAccount(ctx, groupID, "resp_group_removed_session", removedAccount.ID, time.Hour))
+
+	selection, decision, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"resp_group_removed_session",
+		"session_group_removed",
+		"gpt-5.1",
+		nil,
+		OpenAIUpstreamTransportResponsesWebsocketV2,
+		OpenAIEndpointCapabilityChatCompletions,
+		false,
+		true,
+		true,
+		PlatformOpenAI,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, replacementAccount.ID, selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerLoadBalance, decision.Layer)
+	require.False(t, decision.StickyPreviousHit)
+	require.False(t, decision.StickySessionHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+
+	boundResponseAccountID, getErr := store.GetResponseAccount(ctx, groupID, "resp_group_removed_session")
+	require.NoError(t, getErr)
+	require.Zero(t, boundResponseAccountID, "removed account response binding must be invalidated")
+	boundSessionAccountID, getErr := cache.GetSessionAccountID(ctx, groupID, "openai:session_group_removed")
+	require.NoError(t, getErr)
+	require.Equal(t, replacementAccount.ID, boundSessionAccountID, "the whole session route must migrate to the replacement account")
+}
+
+func TestOpenAIGatewayService_SelectAccountWithScheduler_MovableSharedOAuthContinuationUsesAuthorizedMigratedRoute(t *testing.T) {
+	resetOpenAIAdvancedSchedulerSettingCacheForTest()
+	defer resetOpenAIAdvancedSchedulerSettingCacheForTest()
+
+	ctx := oauthSessionPolicyContext(9901)
+	groupID := int64(9020)
+	responseAccount := newOpenAIOAuthSessionPolicyAccount(90201, groupID)
+	migratedAccount := newOpenAIOAuthSessionPolicyAccount(90202, groupID)
+	responseAccount.Priority = 0
+	migratedAccount.Priority = 50
+	responseAccount.Extra["openai_oauth_responses_websockets_v2_enabled"] = true
+	migratedAccount.Extra["openai_oauth_responses_websockets_v2_enabled"] = true
+	cache := &oauthSessionPolicyCache{}
+	svc := &OpenAIGatewayService{
+		accountRepo: &oauthSessionPolicyAccountRepo{accounts: map[int64]*Account{
+			responseAccount.ID: &responseAccount,
+			migratedAccount.ID: &migratedAccount,
+		}},
+		cache:              cache,
+		cfg:                newSchedulerTestOpenAIWSV2Config(),
+		rateLimitService:   newOpenAIAdvancedSchedulerRateLimitService("true"),
+		concurrencyService: NewConcurrencyService(schedulerTestConcurrencyCache{}),
+	}
+	store := svc.getOpenAIWSStateStore()
+	require.NoError(t, svc.bindOpenAIResponseAccount(ctx, store, groupID, &responseAccount, "resp_shared_oauth_before_failover", time.Hour))
+	require.NoError(t, svc.setStickySessionAccountID(ctx, &groupID, "shared_oauth_migrated", migratedAccount.ID, time.Hour))
+
+	selection, decision, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"resp_shared_oauth_before_failover",
+		"shared_oauth_migrated",
+		"gpt-5.1",
+		nil,
+		OpenAIUpstreamTransportAny,
+		OpenAIEndpointCapabilityChatCompletions,
+		false,
+		true,
+		true,
+		PlatformOpenAI,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, selection)
+	require.Equal(t, migratedAccount.ID, selection.Account.ID)
+	require.Equal(t, openAIAccountScheduleLayerSessionSticky, decision.Layer)
+	require.True(t, decision.StickySessionHit)
+	require.False(t, decision.StickyPreviousHit)
+	if selection.ReleaseFunc != nil {
+		selection.ReleaseFunc()
+	}
+
+	nonMovableSelection, nonMovableDecision, err := svc.SelectAccountWithSchedulerForCapability(
+		ctx,
+		&groupID,
+		"resp_shared_oauth_before_failover",
+		"shared_oauth_migrated",
+		"gpt-5.1",
+		nil,
+		OpenAIUpstreamTransportAny,
+		OpenAIEndpointCapabilityChatCompletions,
+		false,
+		false,
+		true,
+		PlatformOpenAI,
+	)
+	require.NoError(t, err)
+	require.NotNil(t, nonMovableSelection)
+	require.Equal(t, responseAccount.ID, nonMovableSelection.Account.ID, "non-movable OAuth continuation must remain on its response owner")
+	require.Equal(t, openAIAccountScheduleLayerPreviousResponse, nonMovableDecision.Layer)
+	require.True(t, nonMovableDecision.StickyPreviousHit)
+	if nonMovableSelection.ReleaseFunc != nil {
+		nonMovableSelection.ReleaseFunc()
 	}
 }
 
@@ -3765,6 +4111,29 @@ func TestDeriveOpenAISelectionSeed_NoAffinityAddsEntropy(t *testing.T) {
 	require.NotZero(t, seed1)
 	require.NotZero(t, seed2)
 	require.NotEqual(t, seed1, seed2)
+}
+
+func TestDeriveOpenAISelectionSeed_StableSessionSupersedesPreviousResponseID(t *testing.T) {
+	groupID := int64(77)
+	base := OpenAIAccountScheduleRequest{
+		GroupID:        &groupID,
+		SessionHash:    "shared_cross_endpoint_session",
+		RequestedModel: "gpt-5.1",
+	}
+	responses := base
+	responses.PreviousResponseID = "resp_endpoint_specific"
+	alphaSearch := base
+
+	require.Equal(t, deriveOpenAISelectionSeed(alphaSearch), deriveOpenAISelectionSeed(responses),
+		"endpoint-specific response IDs must not split a stable session candidate order")
+
+	firstResponseOnly := base
+	firstResponseOnly.SessionHash = ""
+	firstResponseOnly.PreviousResponseID = "resp_first"
+	secondResponseOnly := firstResponseOnly
+	secondResponseOnly.PreviousResponseID = "resp_second"
+	require.NotEqual(t, deriveOpenAISelectionSeed(firstResponseOnly), deriveOpenAISelectionSeed(secondResponseOnly),
+		"previous_response_id remains the fallback identity when no stable session exists")
 }
 
 func TestBuildOpenAIWeightedSelectionOrder_HandlesInvalidScores(t *testing.T) {

--- a/backend/internal/service/openai_cyber_session_block.go
+++ b/backend/internal/service/openai_cyber_session_block.go
@@ -18,10 +18,10 @@ type CyberSessionBlockStore interface {
 	IsCyberSessionBlocked(ctx context.Context, key string) (bool, error)
 }
 
-// CyberSessionBlockKey 派生会话屏蔽 key：仅用显式会话标识（header
-// session_id/conversation_id 或 body prompt_cache_key），混入 apiKeyID 隔离后
-// sha256。无显式标识返回空串——调用方必须放行（粒度决策：不退化到
-// user/apikey/内容派生）。
+// CyberSessionBlockKey 派生会话屏蔽 key：仅用显式会话标识（直接 session
+// header、X-Codex-Turn-Metadata.session_id 或 body prompt_cache_key），混入
+// apiKeyID 隔离后 sha256。无显式标识返回空串——调用方必须放行（粒度决策：
+// 不退化到 user/apikey/内容派生）。
 func CyberSessionBlockKey(apiKeyID int64, c *gin.Context, body []byte) string {
 	raw := explicitOpenAISessionID(c, body)
 	if raw == "" {

--- a/backend/internal/service/openai_cyber_session_block_test.go
+++ b/backend/internal/service/openai_cyber_session_block_test.go
@@ -24,9 +24,9 @@ func newCyberBlockTestCtx(headers map[string]string, body string) (*gin.Context,
 }
 
 // TestCyberSessionBlockKey verifies F5a key derivation: explicit session signals
-// only (header session_id/conversation_id or body prompt_cache_key), apiKey
-// isolated, and EMPTY when no explicit signal (no content-derived fallback —
-// "不退化" decision).
+// only (direct headers, turn-metadata session_id, or body prompt_cache_key),
+// apiKey isolated, and EMPTY when no explicit signal (no content-derived
+// fallback — "不退化" decision).
 func TestCyberSessionBlockKey(t *testing.T) {
 	c1, b1 := newCyberBlockTestCtx(map[string]string{"session_id": "sess-abc"}, `{}`)
 	k1 := CyberSessionBlockKey(101, c1, b1)
@@ -54,6 +54,21 @@ func TestCyberSessionBlockKey(t *testing.T) {
 	require.NotEmpty(t, k6)
 	c6b, b6b := newCyberBlockTestCtx(map[string]string{"conversation_id": "conv-xyz"}, `{}`)
 	require.Equal(t, k6, CyberSessionBlockKey(101, c6b, b6b), "conversation_id key must be stable")
+
+	// Codex turn metadata uses only its stable session_id; turn_id may rotate.
+	c7, b7 := newCyberBlockTestCtx(map[string]string{
+		"X-Codex-Turn-Metadata": `{"session_id":"metadata-session","turn_id":"turn-1"}`,
+	}, `{}`)
+	c7b, b7b := newCyberBlockTestCtx(map[string]string{
+		"X-Codex-Turn-Metadata": `{"session_id":"metadata-session","turn_id":"turn-2"}`,
+	}, `{}`)
+	require.NotEmpty(t, CyberSessionBlockKey(101, c7, b7))
+	require.Equal(t, CyberSessionBlockKey(101, c7, b7), CyberSessionBlockKey(101, c7b, b7b))
+
+	c8, b8 := newCyberBlockTestCtx(map[string]string{
+		"X-Codex-Turn-Metadata": `{"turn_id":"turn-only"}`,
+	}, `{}`)
+	require.Empty(t, CyberSessionBlockKey(101, c8, b8))
 }
 
 // --- fakes ---

--- a/backend/internal/service/openai_gateway_scheduling.go
+++ b/backend/internal/service/openai_gateway_scheduling.go
@@ -52,7 +52,22 @@ func explicitOpenAIHeaderSessionID(c *gin.Context) string {
 			return sessionID
 		}
 	}
-	return ""
+	return openAICodexTurnMetadataSessionID(c.GetHeader("X-Codex-Turn-Metadata"))
+}
+
+// openAICodexTurnMetadataSessionID extracts only the session-scoped identity
+// from Codex turn metadata. turn_id is request-scoped and must never be used for
+// sticky routing, while direct session headers retain precedence in the caller.
+func openAICodexTurnMetadataSessionID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || !gjson.Valid(raw) {
+		return ""
+	}
+	sessionID := gjson.Get(raw, "session_id")
+	if sessionID.Type != gjson.String {
+		return ""
+	}
+	return strings.TrimSpace(sessionID.String())
 }
 
 // ExtractSessionID extracts the raw session ID from headers or body without hashing.
@@ -138,9 +153,10 @@ func (s *OpenAIGatewayService) GenerateExplicitSessionHash(c *gin.Context, body 
 //  3. Header: conversation_id
 //  4. Header: x-session-affinity / x-session-id / x-opencode-session (OpenCode)
 //  5. Header: x-conversation-id (CodeBuddy)
-//  6. Header: x-grok-conv-id (Grok groups only)
-//  7. Body:   prompt_cache_key
-//  8. Body:   content-based fallback (model + system + tools + first user message)
+//  6. Header: x-codex-turn-metadata.session_id
+//  7. Header: x-grok-conv-id (Grok groups only)
+//  8. Body:   prompt_cache_key
+//  9. Body:   content-based fallback (model + system + tools + first user message)
 //
 // Grok sticky affinity is intentionally separate from the upstream
 // prompt_cache_key identity (resolveGrokCacheIdentity): sticky pins an OAuth
@@ -1567,6 +1583,56 @@ func (s *OpenAIGatewayService) openAIAccountMatchesSchedulingGroup(account *Acco
 		return true
 	}
 	return openAIStickyAccountMatchesGroup(account, groupID)
+}
+
+// RevalidateOpenAIAccountForWebSocketTurn reloads an account from the durable
+// repository before an established WebSocket starts another turn. Long-lived
+// connections do not run account selection again, so this is their equivalent
+// of the hard eligibility pass performed for every HTTP request. A nil result
+// means the connection must stop and let a reconnect select another account;
+// repository failures are returned so callers can fail closed.
+func (s *OpenAIGatewayService) RevalidateOpenAIAccountForWebSocketTurn(
+	ctx context.Context,
+	selected *Account,
+	groupID *int64,
+	platform string,
+	requestedModel string,
+	requiredTransport OpenAIUpstreamTransport,
+	requiredCapability OpenAIEndpointCapability,
+) (*Account, error) {
+	if selected == nil {
+		return nil, nil
+	}
+	if s == nil {
+		return nil, nil
+	}
+
+	latest := selected
+	if s.accountRepo != nil {
+		var err error
+		latest, err = s.accountRepo.GetByID(ctx, selected.ID)
+		if err != nil {
+			return nil, fmt.Errorf("reload OpenAI account %d for websocket turn validation: %w", selected.ID, err)
+		}
+	}
+	if latest == nil || !s.openAIAccountMatchesSchedulingGroup(latest, groupID) {
+		return nil, nil
+	}
+	if !isOpenAICompatibleAccountEligibleForRequestBeforeProfit(ctx, latest, platform, requestedModel, false, requiredCapability) {
+		return nil, nil
+	}
+	if !s.isOpenAIAccountTransportCompatible(latest, requiredTransport) {
+		return nil, nil
+	}
+	if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {
+		return nil, nil
+	}
+	if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) ||
+		s.isOpenAIAccountBlockedBySchedulingThreshold(ctx, latest) ||
+		s.isOpenAIProxyStreamQuarantined(ctx, latest) {
+		return nil, nil
+	}
+	return latest, nil
 }
 
 func openAIOAuthSessionPolicyAllowsSchedulingGroup(account *Account, groupID *int64) bool {

--- a/backend/internal/service/openai_gateway_service_test.go
+++ b/backend/internal/service/openai_gateway_service_test.go
@@ -389,6 +389,58 @@ func TestOpenAIGatewayService_GenerateSessionHash_Priority(t *testing.T) {
 	}
 }
 
+func TestOpenAIGatewayService_GenerateSessionHash_CodexTurnMetadataSession(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{}
+	newContext := func(path string, metadata string) *gin.Context {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodPost, path, nil)
+		c.Request.Header.Set("X-Codex-Turn-Metadata", metadata)
+		return c
+	}
+
+	responses := newContext("/openai/v1/responses", `{"session_id":"conversation-42","turn_id":"turn-responses"}`)
+	alphaSearch := newContext("/openai/v1/alpha/search", `{"session_id":"conversation-42","turn_id":"turn-search"}`)
+
+	responsesHash := svc.GenerateSessionHash(responses, []byte(`{"prompt_cache_key":"body-fallback"}`))
+	searchHash := svc.GenerateSessionHashWithFallback(alphaSearch, nil, "search-request-id")
+	require.Equal(t, fmt.Sprintf("%016x", xxhash.Sum64String("conversation-42")), responsesHash)
+	require.Equal(t, responsesHash, searchHash, "Responses and Alpha Search must share the metadata session route")
+}
+
+func TestOpenAIGatewayService_GenerateSessionHash_CodexTurnMetadataSafetyAndPriority(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	svc := &OpenAIGatewayService{}
+
+	t.Run("direct header wins", func(t *testing.T) {
+		recorder := httptest.NewRecorder()
+		c, _ := gin.CreateTestContext(recorder)
+		c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/responses", nil)
+		c.Request.Header.Set("session-id", "direct-session")
+		c.Request.Header.Set("X-Codex-Turn-Metadata", `{"session_id":"metadata-session"}`)
+
+		require.Equal(t, "direct-session", explicitOpenAIHeaderSessionID(c))
+	})
+
+	for name, metadata := range map[string]string{
+		"malformed":     `{"session_id":`,
+		"turn only":     `{"turn_id":"turn-rotates"}`,
+		"non string":    `{"session_id":42}`,
+		"empty session": `{"session_id":"   "}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			recorder := httptest.NewRecorder()
+			c, _ := gin.CreateTestContext(recorder)
+			c.Request = httptest.NewRequest(http.MethodPost, "/openai/v1/alpha/search", nil)
+			c.Request.Header.Set("X-Codex-Turn-Metadata", metadata)
+
+			require.Empty(t, explicitOpenAIHeaderSessionID(c))
+			require.Equal(t, fmt.Sprintf("%016x", xxhash.Sum64String("search-fallback")), svc.GenerateSessionHashWithFallback(c, nil, "search-fallback"))
+		})
+	}
+}
+
 func TestOpenAIGatewayService_ClientSessionHeaderPriority(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	recorder := httptest.NewRecorder()

--- a/backend/internal/service/openai_oauth_session_policy_test.go
+++ b/backend/internal/service/openai_oauth_session_policy_test.go
@@ -160,6 +160,7 @@ func TestOpenAIOAuthSessionPolicy_APIKeyLegacyPolicyKeepsSessionAndResponseBindi
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 1,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
 			OpenAIOAuthSessionPolicyExtraKey: map[string]any{

--- a/backend/internal/service/openai_profit_control_paths_test.go
+++ b/backend/internal/service/openai_profit_control_paths_test.go
@@ -34,6 +34,7 @@ func TestProfitControl_PreviousResponseStickyVetoKeepsBinding(t *testing.T) {
 	groupID := int64(23)
 	now := time.Now()
 	expensive := profitControlWSAccount(31, 0.8, now)
+	expensive.GroupIDs = []int64{groupID}
 
 	cache := &stubGatewayCache{}
 	store := NewOpenAIWSStateStore(cache)
@@ -57,6 +58,7 @@ func TestProfitControl_PreviousResponseStickyVetoKeepsBinding(t *testing.T) {
 
 	// 上游倍率回落（探测刷新）后同一绑定重新可用。
 	recovered := profitControlWSAccount(31, 0.3, time.Now())
+	recovered.GroupIDs = []int64{groupID}
 	svc.accountRepo = stubOpenAIAccountRepo{accounts: []Account{recovered}}
 	selection, err = svc.SelectAccountByPreviousResponseID(ctx, &groupID, "resp_profit", "gpt-5.1", nil, false)
 	require.NoError(t, err)

--- a/backend/internal/service/openai_ws_account_sticky_test.go
+++ b/backend/internal/service/openai_ws_account_sticky_test.go
@@ -2,6 +2,7 @@ package service
 
 import (
 	"context"
+	"fmt"
 	"testing"
 	"time"
 
@@ -19,6 +20,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_Hit(t *testing.T
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 2,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
 		},
@@ -58,6 +60,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_QuotaAutoPausedM
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 2,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
 			"codex_5h_used_percent":                         96.0,
@@ -99,6 +102,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_RateLimitedMiss(
 		Status:           StatusActive,
 		Schedulable:      true,
 		Concurrency:      1,
+		GroupIDs:         []int64{groupID},
 		RateLimitResetAt: &rateLimitedUntil,
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
@@ -136,6 +140,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_DBRuntimeRecheck
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 1,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
 		},
@@ -147,6 +152,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_DBRuntimeRecheck
 		Status:           StatusActive,
 		Schedulable:      true,
 		Concurrency:      1,
+		GroupIDs:         []int64{groupID},
 		RateLimitResetAt: &rateLimitedUntil,
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
@@ -187,6 +193,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_Excluded(t *test
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 1,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_apikey_responses_websockets_v2_enabled": true,
 		},
@@ -219,6 +226,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_ForceHTTPIgnored
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 1,
+		GroupIDs:    []int64{groupID},
 		Extra: map[string]any{
 			"openai_ws_force_http":            true,
 			"responses_websockets_v2_enabled": true,
@@ -254,6 +262,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_BusyKeepsSticky(
 			Schedulable: true,
 			Concurrency: 1,
 			Priority:    0,
+			GroupIDs:    []int64{groupID},
 			Extra: map[string]any{
 				"openai_apikey_responses_websockets_v2_enabled": true,
 			},
@@ -318,6 +327,7 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_CapabilityMismat
 		Status:      StatusActive,
 		Schedulable: true,
 		Concurrency: 1,
+		GroupIDs:    []int64{groupID},
 		Credentials: map[string]any{
 			"openai_capabilities": []any{"chat_completions"},
 		},
@@ -352,6 +362,300 @@ func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_CapabilityMismat
 	boundAccountID, getErr := store.GetResponseAccount(ctx, groupID, "resp_prev_capability")
 	require.NoError(t, getErr)
 	require.Equal(t, account.ID, boundAccountID)
+}
+
+func TestOpenAIGatewayService_SelectAccountByPreviousResponseID_GroupRemovalInvalidatesAllAccountTypes(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(26)
+	otherGroupID := int64(27)
+
+	tests := []struct {
+		name          string
+		accountType   string
+		sharingPolicy bool
+	}{
+		{name: "api key", accountType: AccountTypeAPIKey},
+		{name: "ordinary oauth", accountType: AccountTypeOAuth},
+		{name: "sharing oauth", accountType: AccountTypeOAuth, sharingPolicy: true},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accountID := int64(4100 + index)
+			ownerUserID := int64(9300 + index)
+			requestCtx := ctx
+			if tt.sharingPolicy {
+				requestCtx = oauthSessionPolicyContext(ownerUserID)
+			}
+			wsEnabledKey := "openai_apikey_responses_websockets_v2_enabled"
+			if tt.accountType == AccountTypeOAuth {
+				wsEnabledKey = "openai_oauth_responses_websockets_v2_enabled"
+			}
+			stale := &Account{
+				ID:          accountID,
+				Platform:    PlatformOpenAI,
+				Type:        tt.accountType,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				GroupIDs:    []int64{groupID},
+				Extra:       map[string]any{wsEnabledKey: true},
+			}
+			fresh := *stale
+			fresh.GroupIDs = []int64{otherGroupID}
+			fresh.Extra = map[string]any{wsEnabledKey: true}
+			if tt.sharingPolicy {
+				stale.Extra[OpenAIOAuthSessionPolicyExtraKey] = map[string]any{
+					"enabled":           true,
+					"allowed_group_ids": []int64{groupID},
+					"scope_version":     "scope-before-edit",
+				}
+				fresh.Extra[OpenAIOAuthSessionPolicyExtraKey] = map[string]any{
+					"enabled":           true,
+					"allowed_group_ids": []int64{otherGroupID},
+					"scope_version":     "scope-after-edit",
+				}
+			}
+
+			cache := &stubGatewayCache{}
+			store := NewOpenAIWSStateStore(cache)
+			cfg := newOpenAIWSV2TestConfig()
+			cfg.RunMode = config.RunModeStandard
+			svc := &OpenAIGatewayService{
+				accountRepo:        stubOpenAIAccountRepo{accounts: []Account{fresh}},
+				cache:              cache,
+				cfg:                cfg,
+				concurrencyService: NewConcurrencyService(stubConcurrencyCache{}),
+				openaiWSStateStore: store,
+				schedulerSnapshot: &SchedulerSnapshotService{cache: &openAISnapshotCacheStub{
+					accountsByID: map[int64]*Account{accountID: stale},
+				}},
+			}
+			responseID := fmt.Sprintf("resp_group_removed_%d", index)
+			if tt.sharingPolicy {
+				require.NoError(t, svc.bindOpenAIResponseAccount(requestCtx, store, groupID, stale, responseID, time.Hour))
+			} else {
+				require.NoError(t, store.BindResponseAccount(requestCtx, groupID, responseID, accountID, time.Hour))
+			}
+
+			selection, err := svc.SelectAccountByPreviousResponseID(requestCtx, &groupID, responseID, "gpt-5.1", nil, false)
+			require.NoError(t, err)
+			require.Nil(t, selection)
+			boundAccountID, getErr := store.GetResponseAccount(requestCtx, groupID, responseID)
+			require.NoError(t, getErr)
+			require.Zero(t, boundAccountID, "stale group-local response binding must be removed")
+
+			if tt.sharingPolicy {
+				ownerID, ownerErr := cache.GetSessionAccountID(requestCtx, openAIOAuthSharedSessionCacheGroupID, openAIOAuthSharedResponseOwnerCacheKey(responseID))
+				require.NoError(t, ownerErr)
+				require.Equal(t, ownerUserID, ownerID, "global OAuth response owner marker must remain fail-closed")
+				oldScopeKey := openAIOAuthSharedResponseScopeCacheKey(stale, ownerUserID, responseID)
+				scopedAccountID, scopeErr := cache.GetSessionAccountID(requestCtx, openAIOAuthSharedSessionCacheGroupID, oldScopeKey)
+				require.NoError(t, scopeErr)
+				require.Equal(t, accountID, scopedAccountID, "old OAuth scope marker must not be deleted by a group-local invalidation")
+			}
+		})
+	}
+}
+
+func TestOpenAIGatewayService_RevalidateOpenAIAccountForWebSocketTurn_GroupRemovalInvalidatesAllAccountTypes(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(28)
+	otherGroupID := int64(29)
+
+	tests := []struct {
+		name          string
+		accountType   string
+		sharingPolicy bool
+	}{
+		{name: "api key", accountType: AccountTypeAPIKey},
+		{name: "ordinary oauth", accountType: AccountTypeOAuth},
+		{name: "sharing oauth", accountType: AccountTypeOAuth, sharingPolicy: true},
+	}
+
+	for index, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			accountID := int64(4200 + index)
+			stale := &Account{
+				ID:          accountID,
+				Platform:    PlatformOpenAI,
+				Type:        tt.accountType,
+				Status:      StatusActive,
+				Schedulable: true,
+				Concurrency: 1,
+				GroupIDs:    []int64{groupID},
+				Extra:       map[string]any{},
+			}
+			fresh := *stale
+			fresh.GroupIDs = []int64{otherGroupID}
+			fresh.Extra = map[string]any{}
+			if tt.sharingPolicy {
+				stale.Extra[OpenAIOAuthSessionPolicyExtraKey] = map[string]any{
+					"enabled":           true,
+					"allowed_group_ids": []int64{groupID},
+					"scope_version":     "scope-before-edit",
+				}
+				fresh.Extra[OpenAIOAuthSessionPolicyExtraKey] = map[string]any{
+					"enabled":           true,
+					"allowed_group_ids": []int64{otherGroupID},
+					"scope_version":     "scope-after-edit",
+				}
+			}
+
+			cfg := newOpenAIWSV2TestConfig()
+			cfg.RunMode = config.RunModeStandard
+			svc := &OpenAIGatewayService{
+				accountRepo: stubOpenAIAccountRepo{accounts: []Account{fresh}},
+				cfg:         cfg,
+			}
+
+			latest, err := svc.RevalidateOpenAIAccountForWebSocketTurn(
+				ctx,
+				stale,
+				&groupID,
+				PlatformOpenAI,
+				"gpt-5.1",
+				OpenAIUpstreamTransportAny,
+				OpenAIEndpointCapabilityChatCompletions,
+			)
+			require.NoError(t, err)
+			require.Nil(t, latest, "an established websocket must stop before its next turn after the account leaves the group")
+		})
+	}
+
+	t.Run("repository failure fails closed", func(t *testing.T) {
+		selected := &Account{ID: 4299, Platform: PlatformOpenAI, Type: AccountTypeAPIKey, GroupIDs: []int64{groupID}}
+		cfg := newOpenAIWSV2TestConfig()
+		cfg.RunMode = config.RunModeStandard
+		svc := &OpenAIGatewayService{accountRepo: stubOpenAIAccountRepo{}, cfg: cfg}
+
+		latest, err := svc.RevalidateOpenAIAccountForWebSocketTurn(
+			ctx,
+			selected,
+			&groupID,
+			PlatformOpenAI,
+			"gpt-5.1",
+			OpenAIUpstreamTransportAny,
+			OpenAIEndpointCapabilityChatCompletions,
+		)
+		require.Error(t, err)
+		require.Nil(t, latest)
+	})
+}
+
+func TestOpenAIGatewayService_RevalidateOpenAIAccountForWebSocketTurn_AppliesCurrentHardEligibility(t *testing.T) {
+	ctx := context.Background()
+	groupID := int64(30)
+	base := Account{
+		ID:          4300,
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeAPIKey,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 3,
+		GroupIDs:    []int64{groupID},
+		Extra: map[string]any{
+			"openai_apikey_responses_websockets_v2_enabled": true,
+		},
+	}
+
+	tests := []struct {
+		name              string
+		mutate            func(*Account)
+		model             string
+		requiredTransport OpenAIUpstreamTransport
+	}{
+		{
+			name: "disabled account",
+			mutate: func(account *Account) {
+				account.Status = StatusDisabled
+			},
+			model: "gpt-5.1",
+		},
+		{
+			name: "unschedulable account",
+			mutate: func(account *Account) {
+				account.Schedulable = false
+			},
+			model: "gpt-5.1",
+		},
+		{
+			name: "model removed",
+			mutate: func(account *Account) {
+				account.Credentials = map[string]any{
+					"model_mapping": map[string]any{"gpt-other": "gpt-other"},
+				}
+			},
+			model: "gpt-5.1",
+		},
+		{
+			name: "websocket transport disabled",
+			mutate: func(account *Account) {
+				account.Extra = map[string]any{
+					"openai_apikey_responses_websockets_v2_enabled": false,
+				}
+			},
+			model:             "gpt-5.1",
+			requiredTransport: OpenAIUpstreamTransportResponsesWebsocketV2Ingress,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fresh := base
+			fresh.GroupIDs = append([]int64(nil), base.GroupIDs...)
+			fresh.Extra = map[string]any{
+				"openai_apikey_responses_websockets_v2_enabled": true,
+			}
+			tt.mutate(&fresh)
+			cfg := newOpenAIWSV2TestConfig()
+			cfg.RunMode = config.RunModeStandard
+			svc := &OpenAIGatewayService{
+				accountRepo: stubOpenAIAccountRepo{accounts: []Account{fresh}},
+				cfg:         cfg,
+			}
+
+			requiredTransport := tt.requiredTransport
+			if requiredTransport == "" {
+				requiredTransport = OpenAIUpstreamTransportAny
+			}
+			latest, err := svc.RevalidateOpenAIAccountForWebSocketTurn(
+				ctx,
+				&base,
+				&groupID,
+				PlatformOpenAI,
+				tt.model,
+				requiredTransport,
+				OpenAIEndpointCapabilityChatCompletions,
+			)
+			require.NoError(t, err)
+			require.Nil(t, latest, "an established websocket must stop when a current hard scheduling gate fails")
+		})
+	}
+
+	t.Run("eligible account refreshes current concurrency", func(t *testing.T) {
+		fresh := base
+		fresh.Concurrency = 1
+		cfg := newOpenAIWSV2TestConfig()
+		cfg.RunMode = config.RunModeStandard
+		svc := &OpenAIGatewayService{
+			accountRepo: stubOpenAIAccountRepo{accounts: []Account{fresh}},
+			cfg:         cfg,
+		}
+
+		latest, err := svc.RevalidateOpenAIAccountForWebSocketTurn(
+			ctx,
+			&base,
+			&groupID,
+			PlatformOpenAI,
+			"gpt-5.1",
+			OpenAIUpstreamTransportAny,
+			OpenAIEndpointCapabilityChatCompletions,
+		)
+		require.NoError(t, err)
+		require.NotNil(t, latest)
+		require.Equal(t, 1, latest.Concurrency)
+	})
 }
 
 func newOpenAIWSV2TestConfig() *config.Config {

--- a/backend/internal/service/openai_ws_forwarder_ingress.go
+++ b/backend/internal/service/openai_ws_forwarder_ingress.go
@@ -107,11 +107,9 @@ func (s *OpenAIGatewayService) ProxyResponsesWebSocketFromClient(
 			if wsDecision.Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
 				return fmt.Errorf("websocket ingress requires ws_v2 transport, got=%s", wsDecision.Transport)
 			}
-			// 注意：透传 relay 只回调 hooks.AfterTurn，没有 turn 起始回调，
-			// 因此下面这条路径永远不会触发 hooks.BeforeTurn——分组利润控制的
-			// turn 级复核与 turn 级 pricingAt 冻结都不覆盖透传 ingress，
-			// 只有建连时的准入门生效。handler 侧据此把 turn 定价留作零值，
-			// 由 RecordUsage 回退到记录时刻（见 openAIWSTurnPricing 注释）。
+			// passthrough adapter 会在首帧及后续每个 response.create 发送上游
+			// 前调用 hooks.BeforeTurn，使其与 ctx_pool/http_bridge 共享相同的
+			// 分组硬资格、利润门、计费时刻和并发槽位生命周期。
 			return s.proxyResponsesWebSocketV2Passthrough(
 				ctx,
 				c,

--- a/backend/internal/service/openai_ws_forwarder_support.go
+++ b/backend/internal/service/openai_ws_forwarder_support.go
@@ -488,6 +488,26 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
 		return 0, nil, "", nil, nil
 	}
+	// Snapshot rows may still contain the pre-edit group set. Resolve the
+	// persisted account before any transport, model, or quota short-circuit so a
+	// group removal always invalidates the stale local response binding.
+	if s.schedulerSnapshot != nil && s.accountRepo != nil {
+		latest, latestErr := s.accountRepo.GetByID(ctx, account.ID)
+		if latestErr != nil || latest == nil {
+			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
+			return 0, nil, "", nil, nil
+		}
+		account = latest
+	}
+	// A response binding is group-local, but the account behind it may have been
+	// edited after the binding was written. Apply the same fresh membership
+	// predicate as ordinary sticky routing for API-key, ordinary OAuth, and
+	// sharing-enabled OAuth accounts. Delete only the local binding: shared OAuth
+	// owner/scope markers are a security boundary and must remain fail-closed.
+	if !s.openAIAccountMatchesSchedulingGroup(account, groupID) {
+		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
+		return 0, nil, "", nil, nil
+	}
 	// 非 WSv2 场景（如 force_http/全局关闭）不应使用 previous_response_id 粘连，
 	// 以保持“回滚到 HTTP”后的历史行为一致性。
 	if s.getOpenAIWSProtocolResolver().Resolve(account).Transport != OpenAIUpstreamTransportResponsesWebsocketV2 {
@@ -520,38 +540,9 @@ func (s *OpenAIGatewayService) resolveAccountByPreviousResponseIDForCapability(
 	if vetoed, _ := openAIProfitControlVetoReason(ctx, account); vetoed {
 		return 0, nil, "", nil, nil
 	}
-	if s.schedulerSnapshot != nil && s.accountRepo != nil {
-		latest, latestErr := s.accountRepo.GetByID(ctx, account.ID)
-		if latestErr != nil || latest == nil {
-			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
-			return 0, nil, "", nil, nil
-		}
-		if shouldClearStickySession(latest, requestedModel) || !latest.IsOpenAI() || !latest.IsSchedulable() {
-			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
-			return 0, nil, "", nil, nil
-		}
-		if !parentHealthyForShadow(latest, s.parentAccountLookup(ctx)) {
-			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
-			return 0, nil, "", nil, nil
-		}
-		if requestedModel != "" && !latest.IsModelSupported(requestedModel) {
-			return 0, nil, "", nil, nil
-		}
-		if !latest.SupportsOpenAIEndpointCapability(requiredCapability) {
-			return 0, nil, "", nil, nil
-		}
-		if paused, _ := shouldAutoPauseOpenAIAccountByQuota(ctx, latest); paused {
-			return 0, nil, "", nil, nil
-		}
-		// 利润门对最新账号状态复检一次，语义同上：跳过复用、不删绑定。
-		if vetoed, _ := openAIProfitControlVetoReason(ctx, latest); vetoed {
-			return 0, nil, "", nil, nil
-		}
-		if s.isOpenAIAccountRequestRuntimeBlocked(latest, requestedModel) {
-			_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
-			return 0, nil, "", nil, nil
-		}
-		account = latest
+	if s.isOpenAIAccountRequestRuntimeBlocked(account, requestedModel) {
+		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)
+		return 0, nil, "", nil, nil
 	}
 	if requireCompact && openAICompactSupportTier(account) == 0 {
 		_ = store.DeleteResponseAccount(ctx, derefGroupID(groupID), responseID)

--- a/backend/internal/service/openai_ws_passthrough_turn_pricing_test.go
+++ b/backend/internal/service/openai_ws_passthrough_turn_pricing_test.go
@@ -3,6 +3,7 @@ package service
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"sync"
@@ -60,18 +61,10 @@ func startPassthroughHookRecordingServer(
 	return server, serverErr
 }
 
-// TestPassthroughIngressNeverCallsBeforeTurn 钉死 ws_v2 透传 ingress 与 handler
-// 侧 turn 定价的耦合：透传 relay 只回调 AfterTurn，没有任何 turn 起始回调，
-// 因此 hooks.BeforeTurn 永远不会触发。
-//
-// handler 依赖这一点：openAIWSTurnPricing 零值起步，透传连接的每个 turn 都拿
-// 不到冻结的 pricingAt，RecordUsage 回退到记录时刻——与引入分组利润控制前的
-// 基线一致。若把 turn 定价初始化成建连时刻，透传连接的所有 turn 就会被钉死在
-// 建连时的高峰因子，客户端峰前建连保活即可全程按谷价结算。
-//
-// 若本断言因为透传补齐了 turn 起始回调而失败：这是好事，请同步复核
-// openAIWSTurnPricing 的零值语义与透传路径的 turn 级利润复核。
-func TestPassthroughIngressNeverCallsBeforeTurn(t *testing.T) {
+// TestPassthroughIngressCallsBeforeTurn pins the lifecycle contract shared by
+// every ingress mode: BeforeTurn runs before the first response.create reaches
+// upstream, and AfterTurn runs after its terminal event.
+func TestPassthroughIngressCallsBeforeTurn(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 	controlCtx, cancelControl := context.WithCancelCause(context.Background())
 	defer cancelControl(context.Canceled)
@@ -123,6 +116,73 @@ func TestPassthroughIngressNeverCallsBeforeTurn(t *testing.T) {
 	gotBefore, gotAfter := beforeTurnCalls, afterTurnCalls
 	hooksMu.Unlock()
 
-	require.Zero(t, gotBefore, "透传 ingress 没有 turn 起始回调，BeforeTurn 不应被调用")
+	require.Equal(t, 1, gotBefore, "透传 ingress 必须在首个 response.create 前调用 BeforeTurn")
 	require.Positive(t, gotAfter, "透传 ingress 仍应回调 AfterTurn 提交用量")
+}
+
+func TestPassthroughIngressBeforeTurnRejectsNextTurnBeforeUpstreamWrite(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+	controlCtx, cancelControl := context.WithCancelCause(context.Background())
+	defer cancelControl(context.Canceled)
+
+	upstream := newStagedPassthroughConn()
+	upstream.Send(`{"type":"response.completed","response":{"id":"resp_first","model":"gpt-5.1","usage":{"input_tokens":1,"output_tokens":1}}}`)
+	hookErr := errors.New("account removed from group")
+	var hookMu sync.Mutex
+	hookOrder := make([]string, 0, 4)
+	hooks := &OpenAIWSIngressHooks{
+		MapRequestModel: func(turn int, model string) (string, error) {
+			hookMu.Lock()
+			hookOrder = append(hookOrder, fmt.Sprintf("map:%d", turn))
+			hookMu.Unlock()
+			return model, nil
+		},
+		BeforeTurn: func(turn int) error {
+			hookMu.Lock()
+			hookOrder = append(hookOrder, fmt.Sprintf("before:%d", turn))
+			hookMu.Unlock()
+			if turn > 1 {
+				return hookErr
+			}
+			return nil
+		},
+	}
+
+	server, serverErr := startPassthroughHookRecordingServer(
+		t,
+		controlCtx,
+		newPassthroughLifecycleService(passthroughLifecycleConfig(), upstream),
+		passthroughLifecycleAccount(),
+		hooks,
+	)
+	defer server.Close()
+	clientConn := dialPassthroughLifecycleClient(t, server)
+	defer func() { _ = clientConn.CloseNow() }()
+
+	require.NotEmpty(t, requirePassthroughUpstreamWrite(t, upstream, 3*time.Second))
+	completed, err := readPassthroughLifecycleFrame(t, clientConn, 3*time.Second)
+	require.NoError(t, err)
+	require.Equal(t, "response.completed", gjson.GetBytes(completed, "type").String())
+
+	writeCtx, cancelWrite := context.WithTimeout(context.Background(), 3*time.Second)
+	err = clientConn.Write(writeCtx, coderws.MessageText, []byte(`{"type":"response.create","model":"gpt-5.1","previous_response_id":"resp_first"}`))
+	cancelWrite()
+	require.NoError(t, err)
+
+	select {
+	case err = <-serverErr:
+		require.ErrorIs(t, err, hookErr)
+	case <-time.After(3 * time.Second):
+		t.Fatal("passthrough ingress did not stop after BeforeTurn rejected the next turn")
+	}
+	select {
+	case payload := <-upstream.writes:
+		t.Fatalf("rejected turn reached upstream: %s", payload)
+	case <-time.After(200 * time.Millisecond):
+	}
+	hookMu.Lock()
+	gotHookOrder := append([]string(nil), hookOrder...)
+	hookMu.Unlock()
+	require.Equal(t, []string{"map:1", "before:1", "map:2", "before:2"}, gotHookOrder,
+		"passthrough must resolve the current turn model before durable turn eligibility runs")
 }

--- a/backend/internal/service/openai_ws_v2_passthrough_adapter.go
+++ b/backend/internal/service/openai_ws_v2_passthrough_adapter.go
@@ -717,6 +717,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 			firstClientMessage = s.ReplaceModelInBody(firstClientMessage, mappedModel)
 		}
 	}
+	if hooks != nil && hooks.BeforeTurn != nil {
+		if err := hooks.BeforeTurn(1); err != nil {
+			return err
+		}
+	}
 	capturedSessionModel := openAIWSPassthroughPolicyModelForFrame(account, firstClientMessage)
 	if capturedSessionModel != "" && capturedSessionModel != strings.TrimSpace(gjson.GetBytes(firstClientMessage, "model").String()) {
 		firstClientMessage = s.ReplaceModelInBody(firstClientMessage, capturedSessionModel)
@@ -1005,6 +1010,11 @@ func (s *OpenAIGatewayService) proxyResponsesWebSocketV2Passthrough(
 					}
 					if upstreamModel = strings.TrimSpace(upstreamModel); upstreamModel != "" {
 						payload = s.ReplaceModelInBody(payload, upstreamModel)
+					}
+				}
+				if hooks != nil && hooks.BeforeTurn != nil {
+					if err := hooks.BeforeTurn(turnNo); err != nil {
+						return payload, nil, err
 					}
 				}
 			}

--- a/backend/internal/service/session_id.go
+++ b/backend/internal/service/session_id.go
@@ -40,6 +40,9 @@ func ExtractClientSessionID(c *gin.Context) string {
 			return sessionID
 		}
 	}
+	if sessionID := sanitizeSessionID(openAICodexTurnMetadataSessionID(c.GetHeader("X-Codex-Turn-Metadata"))); sessionID != "" {
+		return sessionID
+	}
 	if isGrokRequestContext(c) {
 		if sessionID := sanitizeSessionID(c.GetHeader(grokConversationIDHeader)); sessionID != "" {
 			return sessionID

--- a/backend/internal/service/session_id_test.go
+++ b/backend/internal/service/session_id_test.go
@@ -108,6 +108,35 @@ func TestExtractClientSessionID_HeaderPrecedence(t *testing.T) {
 	require.Equal(t, "primary", ExtractClientSessionID(c))
 }
 
+func TestExtractClientSessionID_CodexTurnMetadata(t *testing.T) {
+	t.Run("stable metadata session is persisted", func(t *testing.T) {
+		c := newSessionHeaderContext(t, map[string]string{
+			"X-Codex-Turn-Metadata": `{"session_id":"metadata-session","turn_id":"turn-1"}`,
+		})
+		require.Equal(t, "metadata-session", ExtractClientSessionID(c))
+	})
+
+	t.Run("direct session header keeps precedence", func(t *testing.T) {
+		c := newSessionHeaderContext(t, map[string]string{
+			codexSessionIDHeader:    "direct-session",
+			"X-Codex-Turn-Metadata": `{"session_id":"metadata-session"}`,
+		})
+		require.Equal(t, "direct-session", ExtractClientSessionID(c))
+	})
+
+	for name, metadata := range map[string]string{
+		"turn only":           `{"turn_id":"turn-rotates"}`,
+		"malformed":           `{"session_id":`,
+		"non string":          `{"session_id":42}`,
+		"unsafe control char": `{"session_id":"unsafe\nvalue"}`,
+	} {
+		t.Run(name, func(t *testing.T) {
+			c := newSessionHeaderContext(t, map[string]string{"X-Codex-Turn-Metadata": metadata})
+			require.Empty(t, ExtractClientSessionID(c))
+		})
+	}
+}
+
 func TestExtractClientSessionID_Sanitizes(t *testing.T) {
 	c := newSessionHeaderContext(t, map[string]string{openCodeSessionIDHeader: "  clean-123  "})
 	require.Equal(t, "clean-123", ExtractClientSessionID(c))

--- a/docs/protocols/OPENAI_RESPONSES.md
+++ b/docs/protocols/OPENAI_RESPONSES.md
@@ -9,6 +9,14 @@ or bridge the client WebSocket to an HTTP/SSE upstream.
 Current Codex clients can supply the canonical `session-id`, `thread-id`, and
 `x-client-request-id` headers. The gateway also accepts the supported legacy
 session aliases, including `session_id`, for sticky routing compatibility.
+When direct session headers are absent, the stable string `session_id` inside
+`X-Codex-Turn-Metadata` is also accepted; request-scoped `turn_id` is never a
+routing key. This lets `/v1/responses` WebSocket ingress and
+`/v1/alpha/search` share one account route even when Alpha Search would
+otherwise fall back to its search ID.
+The same sanitized value is recorded as `usage_logs.session_id` and participates
+in cyber-session blocking. Endpoint fallbacks and `turn_id` remain routing
+details and are not persisted as client session IDs.
 Thread and client-request identifiers remain paired request context and never
 replace the session-scoped cache identity.
 
@@ -20,6 +28,30 @@ canonical `session-id` header; the legacy `session_id` alias carries the same
 value. A model-only request does not receive a content-derived key. API-key
 Chat Completions requests converted to Responses use the same behavior, while
 raw Chat Completions forwarding does not receive Responses-only cache fields.
+
+Under the default hard-affinity mode, account priority changes do not replace a
+valid active session route. The optional sticky-weighted scheduler mode remains
+score-based by design. If the configured health/concurrency sticky escape
+temporarily bypasses a degraded account, a movable Responses continuation does
+not fall back to that account through its older response ID; the temporary
+candidate order is derived from the shared session identity, while the
+canonical sticky binding remains unchanged. Removing an account from the
+requesting group, disabling it, or making it incompatible is always a hard
+invalidation: both ordinary sticky routing and `previous_response_id` routing
+recheck the current account before reuse. Long-lived Responses WebSocket
+connections also run current billing and reload the selected account before
+every turn in `ctx_pool`, `http_bridge`, and `passthrough` modes. The refreshed
+account must still satisfy group, status, schedulability, quota, client-model,
+endpoint-capability, transport, parent-health, runtime-block, scheduling
+threshold, and proxy-quarantine gates. Follow-up image intent also repeats the
+group permission and Responses-capability checks. If any gate fails, the
+gateway closes before sending that turn upstream; a reconnect then performs
+normal account selection. The first turn is billed-eligible once before
+selection, while every later turn is checked once at its pre-turn boundary. A
+movable WebSocket continuation follows a session route that has already failed
+over to another account and removes the old account's response ID before
+forwarding. Tool-output continuations without complete call context remain on
+the response owner and keep the existing fail-closed OAuth ownership checks.
 
 `prompt_cache_options` is forwarded only for GPT-5.6-family OpenAI Platform
 API-key Responses/Compact traffic. ChatGPT OAuth and older or unknown model

--- a/openspec/changes/fix-openai-session-route-consistency/design.md
+++ b/openspec/changes/fix-openai-session-route-consistency/design.md
@@ -1,0 +1,90 @@
+## Routing invariants
+
+In the default hard-affinity mode, the group-local sticky session is the
+canonical route for a client session and account priority is consulted only
+when no valid route exists. Explicit sticky-weighted mode remains score-based.
+Account status, runtime exclusions, capability, transport, and current group
+membership remain hard eligibility constraints in both modes. Removing an
+account from a group must invalidate both ordinary session affinity and
+response-chain affinity for that group.
+
+`previous_response_id` remains a stronger continuation constraint when the
+request cannot reconstruct its context. When the request is movable, an
+already-established session route may supersede an older response binding; the
+handler must then remove the response ID before forwarding. This makes a
+failover selected by any endpoint visible to the other endpoints without
+sending an account-owned response ID to a different account.
+
+Sticky escape is a temporary exception to the hard-affinity route and keeps the
+canonical session binding unchanged. For a movable continuation, an older
+response binding must not pull the escaped request back to the degraded
+account. Candidate ordering uses the stable session hash alone whenever it is
+available; `previous_response_id` is only a fallback seed when no stable
+session exists, because it is not shared by Alpha Search.
+
+## Canonical Codex session signal
+
+Session resolution keeps the current precedence: direct stable session headers
+first, then the stable `session_id` string inside `X-Codex-Turn-Metadata`, then
+body `prompt_cache_key`, content-derived identity, or an endpoint fallback.
+`turn_id` is deliberately ignored because it changes per request. Malformed
+metadata and non-string or empty session values are ignored.
+
+The same direct-header-first resolution is used when persisting
+`usage_logs.session_id` and deriving cyber-session block keys. Persisted values
+pass through the existing length/control-character sanitizer; routing-only
+fallbacks such as search IDs, request IDs, content hashes, and `turn_id` are
+not written as client session IDs.
+
+This resolution occurs on inbound client values before outbound OAuth
+fingerprint convergence. It does not change the credential-owned/global/default
+outbound identity precedence or reuse an upstream-rewritten identifier as a
+client routing seed.
+
+## Group invalidation and OAuth boundary
+
+The response-account resolver must check the freshly loaded account with the
+same `openAIAccountMatchesSchedulingGroup` predicate used by ordinary sticky
+routing. On mismatch it deletes only the current group's local
+response-to-account binding and returns a cache miss so normal scheduling can
+choose an authorized account. It must not delete the sharing-enabled OAuth
+owner or scope markers, because those markers prevent another user or obsolete
+scope from reviving the response chain.
+
+For sharing-enabled OAuth, selecting another account against an existing
+response ID normally remains fail-closed. The only exception is a movable
+request whose scheduling decision did not hit that response binding, because
+the handler removes the ID before any upstream request. Non-movable tool
+continuations and ownership mismatches continue to fail closed.
+
+An already-established Responses WebSocket cannot change its credential-owning
+upstream account safely between turns. Every ingress mode therefore invokes the
+same `BeforeTurn` boundary before a `response.create` is sent upstream. The
+adapter resolves the current client/channel model first, then the boundary
+reloads the selected account directly from the durable repository and applies
+the same persisted hard account gates as a fresh HTTP selection: current group
+membership, status, schedulability, quota pause, client-model support, endpoint
+capability, transport, shadow-parent health, runtime blocks, scheduling
+thresholds, and proxy stream quarantine. Model eligibility uses the current
+client model, matching HTTP account selection; the channel-mapped model remains
+the upstream and billing mapping rather than replacing the account whitelist
+identity. A mismatch or refresh failure closes the client connection with a
+retryable status; the next connection performs normal scheduling.
+
+The initial WebSocket turn retains the single billing check performed before
+account selection. Every later turn reruns the same billing eligibility method
+before account revalidation, so balance, subscription, user-platform quota,
+API-key limits, and RPM apply once per accepted turn. The follow-up request
+boundary also repeats image-generation group permission and derives the turn's
+endpoint capability before `BeforeTurn`; this closes the passthrough gap while
+ctx-pool and HTTP bridge retain their payload-level checks. All ingress modes
+then share the same per-turn profit, pricing, and concurrency lifecycle.
+
+## Response continuation safety
+
+Client-facing Responses WebSocket ingress already analyzes tool-output
+coverage. A request is movable when it has no tool output, or every tool-output
+call ID has matching call context or an item reference. Only a movable request
+that did not reuse the response binding may have `previous_response_id`
+removed. HTTP Responses continues to reject `previous_response_id` because
+that continuation mode requires Responses WebSocket v2.

--- a/openspec/changes/fix-openai-session-route-consistency/proposal.md
+++ b/openspec/changes/fix-openai-session-route-consistency/proposal.md
@@ -1,0 +1,61 @@
+## Why
+
+OpenAI account-group edits and Codex multi-endpoint conversations currently use
+two partially independent affinity paths. A stored `previous_response_id`
+binding is revalidated for account health and OAuth sharing policy, but not for
+ordinary persisted group membership. Removing an API-key or non-sharing OAuth
+account from a group can therefore leave that group routed to the removed
+account until the response binding expires.
+
+Codex `/v1/responses` and `/v1/alpha/search` requests can also carry the same
+stable session inside `X-Codex-Turn-Metadata`, but the gateway only reads direct
+session headers. Alpha Search then falls back to its per-search ID and can move
+to a newly higher-priority account while Responses remains on the established
+session account. A later safe failover can be blocked again by the old response
+chain, particularly for OAuth accounts with session sharing enabled.
+
+## What Changes
+
+- Treat `X-Codex-Turn-Metadata.session_id` as a stable session signal after
+  direct session headers and before endpoint-specific fallbacks.
+- Revalidate every `previous_response_id` account against the current persisted
+  scheduling group, including API-key, ordinary OAuth, and sharing-enabled
+  OAuth accounts; remove only the stale group-local binding on mismatch.
+- Revalidate the complete persisted hard eligibility of an already-selected
+  account before every turn on all Responses WebSocket ingress modes,
+  including group membership, status, schedulability, quota pause, current
+  client model, endpoint capability, transport, parent health, runtime blocks,
+  scheduling thresholds, and proxy quarantine.
+- Recheck billing eligibility before every follow-up WebSocket turn and apply
+  follow-up image permissions/capability routing before upstream writes, so a
+  long-lived connection cannot bypass checks performed by a fresh HTTP
+  request.
+- Make an already-migrated session binding authoritative over an older response
+  binding when the request contains enough context to move safely.
+- Use the existing WebSocket tool-continuation coverage decision to remove
+  `previous_response_id` only when routing did not reuse its account and the
+  request can reconstruct the continuation from its input.
+- Allow sharing-enabled OAuth failover to select an authorized replacement
+  account when the stale response ID will be removed, while preserving the
+  global owner marker and fail-closed behavior for non-movable or foreign
+  continuations.
+
+## Impact
+
+- Account group removal becomes a hard routing invalidation as soon as the
+  persisted account is rechecked, including on the next turn of an existing
+  WebSocket connection; under the default hard-affinity mode, priority changes
+  remain soft and do not move an active session. Explicit sticky-weighted mode
+  retains its score-based behavior.
+- Responses and Alpha Search share one account route when Codex supplies the
+  same direct session ID or turn-metadata session ID.
+- Usage records and cyber-session blocking use the same sanitized stable
+  turn-metadata session when direct session headers are absent.
+- Every accepted WebSocket turn observes current billing and account policy;
+  an ineligible connection closes before the turn reaches upstream and a
+  reconnect can select another account.
+- A retryable account failure can migrate the shared route once; subsequent
+  movable Responses WebSocket turns follow the replacement account instead of
+  reviving the old response-account binding.
+- No database migration, public request schema change, credential change, or
+  outbound Codex identity precedence change is required.

--- a/openspec/changes/fix-openai-session-route-consistency/specs/openai-session-route-consistency/spec.md
+++ b/openspec/changes/fix-openai-session-route-consistency/specs/openai-session-route-consistency/spec.md
@@ -1,0 +1,159 @@
+## ADDED Requirements
+
+### Requirement: Active OpenAI sessions must use one cross-endpoint account route
+
+The gateway SHALL derive the same sticky route for Responses and Alpha Search
+when they carry the same stable client session. Direct stable session headers
+MUST take precedence over `X-Codex-Turn-Metadata.session_id`, and per-request
+turn identifiers MUST NOT be used as session routes.
+
+#### Scenario: Responses and Alpha Search share turn metadata
+
+- **WHEN** both endpoints carry the same non-empty turn-metadata `session_id`
+  and different request or search identifiers
+- **THEN** they MUST derive the same session route
+- **THEN** under the default hard-affinity mode, a priority change MUST NOT move
+  only one endpoint to another account
+
+#### Scenario: Direct session header conflicts with metadata
+
+- **WHEN** a request supplies both a direct `session-id` and a different
+  turn-metadata `session_id`
+- **THEN** the direct header MUST determine the route
+
+#### Scenario: Metadata contains only a turn identifier
+
+- **WHEN** turn metadata is malformed or contains no stable string `session_id`
+- **THEN** it MUST NOT replace the endpoint's existing fallback behavior
+
+#### Scenario: Usage is correlated from turn metadata
+
+- **WHEN** a successful OpenAI request has no direct session header and carries
+  a valid turn-metadata `session_id`
+- **THEN** its usage record and cyber-session key MUST use that sanitized
+  stable session value
+- **THEN** a search ID, request ID, content hash, or `turn_id` MUST NOT be
+  persisted as the client session ID
+
+### Requirement: Current group membership must gate response continuation
+
+Every account resolved from a `previous_response_id` SHALL be revalidated
+against the current persisted scheduling group before forwarding. A mismatch
+MUST invalidate the current group's local response binding and MUST NOT delete
+OAuth global ownership markers.
+
+#### Scenario: API-key account is removed from a group
+
+- **WHEN** a response binding points to an API-key account that no longer
+  belongs to the requesting group
+- **THEN** the gateway MUST NOT reuse that account
+- **THEN** normal scheduling MAY select another account in the group
+
+#### Scenario: Ordinary OAuth account is removed from a group
+
+- **WHEN** session sharing is disabled and the bound OAuth account no longer
+  belongs to the requesting group
+- **THEN** the gateway MUST apply the same invalidation as for an API-key
+  account
+
+#### Scenario: Sharing-enabled OAuth policy changes
+
+- **WHEN** the requesting group is removed from the bound OAuth account's
+  validated sharing policy
+- **THEN** the local group binding MUST be invalidated
+- **THEN** the global response owner and scope markers MUST remain intact
+
+### Requirement: Existing WebSocket connections must revalidate each turn
+
+Before forwarding each Responses WebSocket turn, every ingress mode SHALL
+apply billing eligibility once for that turn and SHALL reload the connection's
+selected account from persistent storage. The refreshed account SHALL pass
+current group, status, schedulability, quota, client-model, endpoint-capability,
+transport, parent-health, runtime-block, threshold, and proxy-quarantine gates.
+A mismatch or inability to refresh the account MUST fail closed before that
+turn reaches upstream.
+
+#### Scenario: Account leaves the group while a WebSocket remains connected
+
+- **WHEN** an API-key, ordinary OAuth, or sharing-enabled OAuth account was
+  valid when the connection opened but is removed from the requesting group
+  before a later turn
+- **THEN** the gateway MUST NOT forward that later turn on the existing
+  upstream connection
+- **THEN** it MUST close the client connection with a retryable status so a
+  reconnect can run normal scheduling
+
+#### Scenario: Passthrough connection starts another turn
+
+- **WHEN** a passthrough WebSocket receives a subsequent `response.create`
+- **THEN** it MUST run the same pre-turn group, profit, pricing, and concurrency
+  lifecycle as ctx-pool and HTTP-bridge ingress before writing upstream
+
+#### Scenario: Billing eligibility changes between turns
+
+- **WHEN** the first turn passed billing but a later turn no longer has an
+  eligible balance, subscription, quota, API-key limit, or RPM decision
+- **THEN** the later turn MUST NOT reach upstream
+- **THEN** the first turn and each attempted follow-up MUST be checked exactly
+  once rather than double-counting the first turn
+
+#### Scenario: Current account becomes otherwise ineligible
+
+- **WHEN** an established connection's account is disabled, unschedulable,
+  quota-paused, incompatible with the current client model/capability/transport,
+  parent-unhealthy, runtime-blocked, threshold-blocked, or proxy-quarantined
+- **THEN** the gateway MUST close before forwarding the next turn and require a
+  reconnect for normal account selection
+
+#### Scenario: Follow-up turn introduces image generation
+
+- **WHEN** a later `response.create` introduces explicit image-generation
+  intent
+- **THEN** every ingress mode MUST recheck the group's image permission and the
+  selected account's Responses capability before writing upstream
+
+#### Scenario: Channel mapping differs from account whitelist identity
+
+- **WHEN** the current client model is allowed by the selected account and a
+  channel maps it to a different upstream model
+- **THEN** durable eligibility MUST validate the client model as HTTP selection
+  does
+- **THEN** the mapped model MUST still be used for upstream forwarding and
+  mapping-aware usage attribution
+
+### Requirement: Safe failover must migrate the whole session route
+
+An established replacement session route SHALL supersede an older response
+binding only when a Responses WebSocket request can reconstruct its
+continuation without that response ID. The WebSocket handler MUST remove the
+stale ID before forwarding to the replacement account.
+
+#### Scenario: Alpha Search failure moves the shared session
+
+- **WHEN** Alpha Search fails over from account A to account B and updates the
+  shared session route
+- **THEN** a later movable Responses request in that session MUST select B
+- **THEN** it MUST NOT send account A's `previous_response_id` to B
+
+#### Scenario: Tool continuation cannot be reconstructed
+
+- **WHEN** a Responses request has tool outputs whose call context is not fully
+  present in the input
+- **THEN** the gateway MUST NOT remove `previous_response_id`
+- **THEN** OAuth response ownership validation MUST remain fail closed
+
+#### Scenario: Movable continuation temporarily escapes a degraded sticky account
+
+- **WHEN** sticky escape is enabled, the canonical session account is degraded,
+  and a movable Responses request also carries that account's response ID
+- **THEN** the old response binding MUST NOT cancel the session sticky escape
+- **THEN** the temporary replacement selection MUST preserve the canonical
+  sticky binding and MUST use the stable session as its cross-endpoint seed
+
+#### Scenario: Sharing-enabled OAuth replacement is authorized
+
+- **WHEN** an old OAuth response route is invalid, another sharing-enabled
+  OAuth account is authorized for the group, and the request is movable
+- **THEN** the replacement account MAY be selected
+- **THEN** ownership validation of the removed response ID MUST NOT reject the
+  replacement before forwarding

--- a/openspec/changes/fix-openai-session-route-consistency/tasks.md
+++ b/openspec/changes/fix-openai-session-route-consistency/tasks.md
@@ -1,0 +1,33 @@
+## 1. Routing behavior
+
+- [x] 1.1 Read the stable Codex turn-metadata session ID in the common OpenAI
+  session resolver and keep direct-header precedence.
+- [x] 1.2 Revalidate response-account bindings against current persisted group
+  membership and clean stale local bindings for every OpenAI account type.
+- [x] 1.3 Prefer a migrated session route for movable WebSocket continuations
+  and preserve the existing response-ID removal safety check.
+- [x] 1.4 Permit authorized sharing-enabled OAuth migration only when the old
+  response ID is guaranteed to be removed.
+- [x] 1.5 Keep movable sticky escape from falling back to the old response
+  owner, and make stable-session candidate ordering endpoint-independent.
+- [x] 1.6 Revalidate complete durable account eligibility before every turn of
+  an existing Responses WebSocket and invoke the boundary in passthrough mode
+  as well as ctx-pool and HTTP bridge modes.
+- [x] 1.7 Recheck billing on each follow-up turn, retain exactly one first-turn
+  billing check, and enforce follow-up image permission/capability before
+  upstream writes.
+- [x] 1.8 Persist the sanitized turn-metadata session in usage correlation and
+  use it consistently for cyber-session blocking.
+
+## 2. Documentation and verification
+
+- [x] 2.1 Document the turn-metadata routing signal and hard/soft invalidation
+  behavior in the OpenAI Responses protocol guide.
+- [x] 2.2 Add focused tests for direct-header precedence, cross-endpoint session
+  hashes, API-key and ordinary/shared OAuth group removal, migrated session
+  precedence, movable sticky escape, endpoint-independent selection seeds, and
+  non-movable fail-closed behavior, including passthrough hook ordering,
+  full-account and billing rejection before an ineligible turn reaches
+  upstream.
+- [x] 2.3 Run Go formatting, focused backend tests, strict OpenSpec validation,
+  and `git diff --check`.

--- a/release-notes.md
+++ b/release-notes.md
@@ -18,6 +18,16 @@ Sub2API Plus v0.1.177+custom.002
 
 ## Fixed
 
+- Revalidate OpenAI API-key and OAuth response/session affinity against current
+  group membership and full account eligibility, including every turn of an
+  already-established Responses WebSocket in all ingress modes. Follow-up
+  turns now recheck billing, current model/capability/transport, and image
+  permission before upstream writes, so policy changes take effect without
+  waiting for sticky bindings or long-lived connections to expire.
+- Keep Codex Responses and Alpha Search on one account route by recognizing the
+  stable session in turn metadata; usage correlation and cyber-session blocking
+  now use the same sanitized session value, and default hard-affinity priority
+  changes no longer split an active conversation across accounts.
 - Preserve configured image storage for already-accepted task completion and
   historical ZIP downloads when administrators disable only new submissions.
 - Delete Redis task state atomically only while its current status is `failed`,


### PR DESCRIPTION
## Summary

Submit `fix/openai-session-route-consistency` after the repository local-validation gate.

## Validation

- Platform-container validation matrix passed.

<!-- sub2api-submit-pr: {"base":"063d55022d103af9c111870a05226946735099c2","head":"3df7ae1bc09527db353247858f17326bd82a0b13"} -->
