### PR TITLE
feat(codex): default OAuth fingerprint mode to device

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ FROM --platform=${BUILDPLATFORM} ${NODE_IMAGE} AS frontend-builder
 ARG NPM_CONFIG_REGISTRY
 
 WORKDIR /app/frontend
-ENV NODE_OPTIONS=--max-old-space-size=1536
+ENV NODE_OPTIONS=--max-old-space-size=3072
 
 # Install pnpm (pinned to v9 to match CI and keep builds reproducible)
 RUN corepack enable && corepack prepare pnpm@9 --activate

--- a/backend/internal/repository/account_repo.go
+++ b/backend/internal/repository/account_repo.go
@@ -170,6 +170,9 @@ func createAccountRecord(ctx context.Context, client *dbent.Client, account *ser
 	if account == nil {
 		return service.ErrAccountNilInput
 	}
+	if err := account.NormalizeCodexFingerprintMode(); err != nil {
+		return err
+	}
 
 	builder := client.Account.Create().
 		SetName(account.Name).
@@ -492,6 +495,9 @@ func (r *accountRepository) updateAccount(
 ) error {
 	if account == nil {
 		return nil
+	}
+	if err := account.NormalizeCodexFingerprintMode(); err != nil {
+		return err
 	}
 
 	baseCtx := ctx
@@ -2875,11 +2881,6 @@ func ollamaCloudUsageSnapshotClearRequested(extra map[string]any) bool {
 	return ok && value == nil
 }
 
-func codexFingerprintModeClearRequested(extra map[string]any) bool {
-	value, ok := extra[service.CodexFingerprintModeExtraKey]
-	return ok && value == nil
-}
-
 func (r *accountRepository) BulkUpdate(ctx context.Context, ids []int64, updates service.AccountBulkUpdate) (int64, error) {
 	if len(ids) == 0 {
 		return 0, nil
@@ -2986,9 +2987,6 @@ func (r *accountRepository) BulkUpdate(ctx context.Context, ids []int64, updates
 			}
 			if ollamaCloudUsageSnapshotClearRequested(updates.Extra) {
 				extraExpression = "(" + extraExpression + ") - 'ollama_cloud_usage_snapshot'"
-			}
-			if codexFingerprintModeClearRequested(updates.Extra) {
-				extraExpression = "(" + extraExpression + ") - 'codex_fingerprint_mode'"
 			}
 		}
 		eligibleAccount := "platform IN ('openai', 'anthropic') AND type = 'apikey'"

--- a/backend/internal/repository/account_repo_codex_fingerprint_update_test.go
+++ b/backend/internal/repository/account_repo_codex_fingerprint_update_test.go
@@ -8,15 +8,26 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestBulkUpdateNilCodexFingerprintModeRemovesKeyInsteadOfWritingJSONNull(t *testing.T) {
+func TestBulkUpdateExplicitCodexFingerprintModeMergesValue(t *testing.T) {
 	exec := &recordingSQLExecutor{result: rowsAffectedResult(1)}
 	repo := newAccountRepositoryWithSQL(nil, exec, nil)
 
 	_, err := repo.BulkUpdate(context.Background(), []int64{27}, service.AccountBulkUpdate{
-		Extra: map[string]any{service.CodexFingerprintModeExtraKey: nil},
+		Extra: map[string]any{service.CodexFingerprintModeExtraKey: "device"},
 	})
 
 	require.NoError(t, err)
 	require.NotEmpty(t, exec.execQueries)
-	require.Contains(t, normalizeSQLWhitespace(exec.execQueries[0]), "- 'codex_fingerprint_mode'")
+	query := normalizeSQLWhitespace(exec.execQueries[0])
+	require.Contains(t, query, "extra = COALESCE(extra, '{}'::jsonb) || $1::jsonb")
+	require.NotContains(t, query, "- 'codex_fingerprint_mode'")
+	payload, ok := exec.execArgs[0][0].([]byte)
+	require.True(t, ok)
+	require.JSONEq(t, `{"codex_fingerprint_mode":"device"}`, string(payload))
+}
+
+func TestCodexFingerprintModeExtraUpdateIsSchedulerRelevant(t *testing.T) {
+	require.True(t, shouldEnqueueSchedulerOutboxForExtraUpdates(map[string]any{
+		service.CodexFingerprintModeExtraKey: "device",
+	}))
 }

--- a/backend/internal/repository/codex_fingerprint_mode_migration_integration_test.go
+++ b/backend/internal/repository/codex_fingerprint_mode_migration_integration_test.go
@@ -1,0 +1,121 @@
+//go:build integration
+
+package repository
+
+import (
+	"context"
+	"testing"
+
+	dbmigrations "github.com/LuckyKuang/sub2api-plus/migrations"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigration224EnforcesExplicitCodexFingerprintMode(t *testing.T) {
+	tx := testTx(t)
+	ctx := context.Background()
+	migrationSQL, err := dbmigrations.FS.ReadFile("224_backfill_codex_fingerprint_mode.sql")
+	require.NoError(t, err)
+
+	_, err = tx.ExecContext(ctx, `
+DROP TRIGGER IF EXISTS accounts_enforce_codex_fingerprint_mode_extra ON accounts;
+`)
+	require.NoError(t, err)
+
+	var missingID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+INSERT INTO accounts (name, platform, type, extra)
+VALUES ('migration-224-missing', 'openai', 'oauth', '{}'::jsonb)
+RETURNING id
+`).Scan(&missingID))
+
+	var explicitSessionID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+INSERT INTO accounts (name, platform, type, extra)
+VALUES ('migration-224-session', 'openai', 'oauth', '{"codex_fingerprint_mode":"session"}'::jsonb)
+RETURNING id
+`).Scan(&explicitSessionID))
+
+	var malformedID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+INSERT INTO accounts (name, platform, type, extra)
+VALUES ('migration-224-malformed', 'openai', 'oauth', '{"codex_fingerprint_mode":false}'::jsonb)
+RETURNING id
+`).Scan(&malformedID))
+
+	var shadowID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+INSERT INTO accounts (name, platform, type, extra, parent_account_id, quota_dimension)
+VALUES ('migration-224-shadow', 'openai', 'oauth', '{"codex_fingerprint_mode":"session"}'::jsonb, $1, 'spark')
+RETURNING id
+`, explicitSessionID).Scan(&shadowID))
+
+	var apiKeyID int64
+	require.NoError(t, tx.QueryRowContext(ctx, `
+INSERT INTO accounts (name, platform, type, extra)
+VALUES ('migration-224-apikey', 'openai', 'apikey', '{"codex_fingerprint_mode":"session"}'::jsonb)
+RETURNING id
+`).Scan(&apiKeyID))
+
+	_, err = tx.ExecContext(ctx, string(migrationSQL))
+	require.NoError(t, err)
+	_, err = tx.ExecContext(ctx, string(migrationSQL))
+	require.NoError(t, err)
+
+	assertMode := func(id int64, expected string) {
+		t.Helper()
+		var mode string
+		require.NoError(t, tx.QueryRowContext(ctx, `
+SELECT extra->>'codex_fingerprint_mode' FROM accounts WHERE id = $1
+`, id).Scan(&mode))
+		require.Equal(t, expected, mode)
+	}
+	assertMode(missingID, "device")
+	assertMode(explicitSessionID, "session")
+	assertMode(malformedID, "device")
+
+	var shadowHasMode bool
+	require.NoError(t, tx.QueryRowContext(ctx, `
+SELECT extra ? 'codex_fingerprint_mode' FROM accounts WHERE id = $1
+`, shadowID).Scan(&shadowHasMode))
+	require.False(t, shadowHasMode)
+	var apiKeyHasMode bool
+	require.NoError(t, tx.QueryRowContext(ctx, `
+SELECT extra ? 'codex_fingerprint_mode' FROM accounts WHERE id = $1
+`, apiKeyID).Scan(&apiKeyHasMode))
+	require.False(t, apiKeyHasMode)
+
+	_, err = tx.ExecContext(ctx, `
+UPDATE accounts SET extra = extra - 'codex_fingerprint_mode' WHERE id = $1
+`, explicitSessionID)
+	require.NoError(t, err)
+	assertMode(explicitSessionID, "session")
+	_, err = tx.ExecContext(ctx, `
+UPDATE accounts
+SET extra = jsonb_set(extra, '{codex_fingerprint_mode}', 'null'::jsonb, true)
+WHERE id = $1
+`, explicitSessionID)
+	require.NoError(t, err)
+	assertMode(explicitSessionID, "device")
+
+	var insertedMode string
+	require.NoError(t, tx.QueryRowContext(ctx, `
+INSERT INTO accounts (name, platform, type, extra)
+VALUES ('migration-224-new-default', 'openai', 'oauth', '{}'::jsonb)
+RETURNING extra->>'codex_fingerprint_mode'
+`).Scan(&insertedMode))
+	require.Equal(t, "device", insertedMode)
+
+	var apiKeyRetainedMode bool
+	require.NoError(t, tx.QueryRowContext(ctx, `
+INSERT INTO accounts (name, platform, type, extra)
+VALUES ('migration-224-new-apikey', 'openai', 'apikey', '{"codex_fingerprint_mode":"device"}'::jsonb)
+RETURNING extra ? 'codex_fingerprint_mode'
+`).Scan(&apiKeyRetainedMode))
+	require.False(t, apiKeyRetainedMode)
+
+	_, err = tx.ExecContext(ctx, `
+INSERT INTO accounts (name, platform, type, extra)
+VALUES ('migration-224-invalid', 'openai', 'oauth', '{"codex_fingerprint_mode":"invalid"}'::jsonb)
+`)
+	require.ErrorContains(t, err, "codex_fingerprint_mode must be one of")
+}

--- a/backend/internal/service/account_service.go
+++ b/backend/internal/service/account_service.go
@@ -266,6 +266,9 @@ func (s *AccountService) Create(ctx context.Context, req CreateAccountRequest) (
 	} else {
 		account.AutoPauseOnExpired = true
 	}
+	if err := account.NormalizeCodexFingerprintMode(); err != nil {
+		return nil, err
+	}
 
 	if err := s.accountRepo.Create(ctx, account); err != nil {
 		return nil, fmt.Errorf("create account: %w", err)
@@ -357,7 +360,9 @@ func (s *AccountService) Update(ctx context.Context, id int64, req UpdateAccount
 		delete(extra, OllamaCloudUsageSessionExtraKey)
 		delete(extra, OllamaCloudUsageAutoRefreshExtraKey)
 		delete(extra, OllamaCloudUsageSnapshotExtraKey)
-		account.Extra = extra
+		account.Extra = withExistingCodexFingerprintModeIfOmitted(account, extra)
+	} else {
+		canonicalizeCodexFingerprintModeForOmittedExtraUpdate(account)
 	}
 
 	if req.ProxyID != nil {
@@ -380,6 +385,9 @@ func (s *AccountService) Update(ctx context.Context, id int64, req UpdateAccount
 	}
 	if req.AutoPauseOnExpired != nil {
 		account.AutoPauseOnExpired = *req.AutoPauseOnExpired
+	}
+	if err := account.NormalizeCodexFingerprintMode(); err != nil {
+		return nil, err
 	}
 
 	// 先验证分组是否存在（在任何写操作之前）

--- a/backend/internal/service/account_test_service.go
+++ b/backend/internal/service/account_test_service.go
@@ -2092,7 +2092,7 @@ func (s *AccountTestService) testOpenAICompactConnection(c *gin.Context, account
 		// 指纹收敛：探测与真实转发走同一个 /responses 端点，身份也必须同构，
 		// 否则探测流量会以「缺 x-codex-installation-id + 非收敛 session」的
 		// 形态暴露在上游眼里。账号关闭收敛（off）时返回 nil，探测保持原样。
-		if fpIDs := resolveCodexFingerprintIDsFromRequest(account, req.Header); fpIDs != nil {
+		if fpIDs := resolveCodexFingerprintIDsFromRequest(credentialAccount, req.Header); fpIDs != nil {
 			applyCodexFingerprintHeaders(req.Header, fpIDs)
 		}
 	}

--- a/backend/internal/service/account_test_service_openai_compact_test.go
+++ b/backend/internal/service/account_test_service_openai_compact_test.go
@@ -283,7 +283,7 @@ func TestAccountTestService_TestAccountConnection_OpenAICompactProbeIdentityMatc
 			"access_token":       "oauth-token",
 			"chatgpt_account_id": "chatgpt-acc",
 		},
-		// 收敛是显式 opt-in（#5610），这里显式开启以验证探测身份与真实流量同构。
+		// 显式启用更强的 session 收敛，以验证探测身份与真实流量同构。
 		Extra: map[string]any{"codex_fingerprint_mode": "session"},
 	}
 	repo := &snapshotUpdateAccountRepo{
@@ -311,6 +311,59 @@ func TestAccountTestService_TestAccountConnection_OpenAICompactProbeIdentityMatc
 		"真实 Codex 每个请求必带 installation-id，探测不得缺失")
 	require.NotContains(t, upstream.lastReq.Header.Get("session-id"), "probe_compact",
 		"探测标识不得是可被上游一眼识别的字面量")
+	<-updateCalls
+}
+
+func TestAccountTestService_TestAccountConnection_OpenAICompactShadowUsesOwnerFingerprintMode(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	updateCalls := make(chan map[string]any, 1)
+	owner := Account{
+		ID:          7,
+		Name:        "openai-oauth-owner",
+		Platform:    PlatformOpenAI,
+		Type:        AccountTypeOAuth,
+		Status:      StatusActive,
+		Schedulable: true,
+		Concurrency: 1,
+		Credentials: map[string]any{
+			"access_token":       "oauth-token",
+			"chatgpt_account_id": "chatgpt-acc",
+		},
+		Extra: map[string]any{CodexFingerprintModeExtraKey: "session"},
+	}
+	ownerID := owner.ID
+	shadow := Account{
+		ID:              8,
+		Name:            "openai-oauth-shadow",
+		Platform:        PlatformOpenAI,
+		Type:            AccountTypeOAuth,
+		Status:          StatusActive,
+		Schedulable:     true,
+		Concurrency:     1,
+		ParentAccountID: &ownerID,
+		QuotaDimension:  QuotaDimensionSpark,
+	}
+	repo := &snapshotUpdateAccountRepo{
+		stubOpenAIAccountRepo: stubOpenAIAccountRepo{accounts: []Account{owner, shadow}},
+		updateExtraCalls:      updateCalls,
+	}
+	upstream := &httpUpstreamRecorder{resp: &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"text/event-stream"}},
+		Body:       io.NopCloser(strings.NewReader(compactProbeSSESuccessBody)),
+	}}
+	svc := &AccountTestService{accountRepo: repo, httpUpstream: upstream}
+
+	rec := httptest.NewRecorder()
+	c, _ := gin.CreateTestContext(rec)
+	c.Request = httptest.NewRequest(http.MethodPost, "/api/v1/admin/accounts/8/test", bytes.NewReader(nil))
+
+	require.NoError(t, svc.TestAccountConnection(c, shadow.ID, "gpt-5.4", "", AccountTestModeCompact))
+
+	require.Equal(t, resolveConvergedSessionID(&owner), upstream.lastReq.Header.Get("session-id"))
+	require.Equal(t, resolveConvergedInstallationID(&owner), upstream.lastReq.Header.Get("x-codex-installation-id"))
+	require.NotEqual(t, resolveConvergedInstallationID(&shadow), upstream.lastReq.Header.Get("x-codex-installation-id"))
 	<-updateCalls
 }
 

--- a/backend/internal/service/admin_account.go
+++ b/backend/internal/service/admin_account.go
@@ -420,6 +420,9 @@ func buildAccountForCreate(input *CreateAccountInput, accountExtra map[string]an
 		Status:      StatusActive,
 		Schedulable: true,
 	}
+	if err := account.NormalizeCodexFingerprintMode(); err != nil {
+		return nil, err
+	}
 	if input.ProbeEnabled != nil && *input.ProbeEnabled {
 		if !isUpstreamBillingProbeAccount(account) {
 			return nil, ErrUpstreamBillingProbeAccountInvalid
@@ -593,6 +596,9 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 		if err != nil {
 			return nil, err
 		}
+		normalizedExtra = withExistingCodexFingerprintModeIfOmitted(account, normalizedExtra)
+	} else {
+		canonicalizeCodexFingerprintModeForOmittedExtraUpdate(account)
 	}
 	previousProbeIdentity := upstreamBillingProbeIdentity(account)
 	previousOllamaUsageIdentity := ollamaCloudUsageIdentity(account)
@@ -883,6 +889,9 @@ func (s *adminServiceImpl) UpdateAccount(ctx context.Context, id int64, input *U
 	if err != nil {
 		return nil, err
 	}
+	if err := account.NormalizeCodexFingerprintMode(); err != nil {
+		return nil, err
+	}
 
 	// Spark shadows borrow their credential owner's OAuth session policy. Keep
 	// policy, proxy, group bindings, and billing writes within one transaction
@@ -966,6 +975,9 @@ func (s *adminServiceImpl) UpdateAccountExtra(ctx context.Context, id int64, upd
 	delete(updates, OllamaCloudUsageSessionExtraKey)
 	delete(updates, OllamaCloudUsageAutoRefreshExtraKey)
 	delete(updates, OllamaCloudUsageSnapshotExtraKey)
+	if err := normalizeCodexFingerprintModeUpdateExtra(updates); err != nil {
+		return err
+	}
 	if _, exists := updates[openAILongContextBillingEnabledKey]; exists {
 		account, err := s.accountRepo.GetByID(ctx, id)
 		if err != nil {
@@ -994,6 +1006,9 @@ func (s *adminServiceImpl) BulkUpdateAccounts(ctx context.Context, input *BulkUp
 	delete(input.Extra, OllamaCloudUsageSessionExtraKey)
 	delete(input.Extra, OllamaCloudUsageAutoRefreshExtraKey)
 	delete(input.Extra, OllamaCloudUsageSnapshotExtraKey)
+	if err := normalizeCodexFingerprintModeUpdateExtra(input.Extra); err != nil {
+		return nil, err
+	}
 
 	if len(input.AccountIDs) == 0 && input.Filters != nil {
 		accountIDs, err := s.resolveBulkUpdateTargetIDs(ctx, input.Filters)

--- a/backend/internal/service/openai_codex_fingerprint.go
+++ b/backend/internal/service/openai_codex_fingerprint.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	infraerrors "github.com/LuckyKuang/sub2api-plus/internal/pkg/errors"
 	"github.com/gin-gonic/gin"
 	"github.com/google/uuid"
 	"github.com/tidwall/gjson"
@@ -37,25 +38,124 @@ const (
 	codexFingerprintFull codexFingerprintMode = "full"
 )
 
-// CodexFingerprintModeExtraKey is exported for persistence layers that need
-// to remove the key when an administrator restores the implicit session mode.
+// CodexFingerprintModeExtraKey is the canonical persisted fingerprint mode.
 const CodexFingerprintModeExtraKey = "codex_fingerprint_mode"
+
+func normalizeCodexFingerprintMode(raw any) (codexFingerprintMode, error) {
+	if raw == nil {
+		return codexFingerprintDevice, nil
+	}
+	value, ok := raw.(string)
+	if !ok {
+		return "", infraerrors.BadRequest(
+			"CODEX_FINGERPRINT_MODE_INVALID",
+			"codex_fingerprint_mode must be one of off, device, session, full",
+		)
+	}
+	mode := codexFingerprintMode(strings.TrimSpace(value))
+	if mode == "" {
+		return codexFingerprintDevice, nil
+	}
+	switch mode {
+	case codexFingerprintOff, codexFingerprintDevice, codexFingerprintSession, codexFingerprintFull:
+		return mode, nil
+	default:
+		return "", infraerrors.BadRequest(
+			"CODEX_FINGERPRINT_MODE_INVALID",
+			"codex_fingerprint_mode must be one of off, device, session, full",
+		)
+	}
+}
+
+// NormalizeCodexFingerprintMode persists an explicit canonical mode for every
+// credential-owning OpenAI OAuth account. Shadows inherit their parent's mode.
+func (a *Account) NormalizeCodexFingerprintMode() error {
+	if a == nil {
+		return nil
+	}
+	if !a.IsOpenAIOAuth() || a.IsCredentialShadow() {
+		if a.Extra != nil {
+			delete(a.Extra, CodexFingerprintModeExtraKey)
+		}
+		return nil
+	}
+	var raw any
+	if a.Extra != nil {
+		raw = a.Extra[CodexFingerprintModeExtraKey]
+	}
+	mode, err := normalizeCodexFingerprintMode(raw)
+	if err != nil {
+		return err
+	}
+	if a.Extra == nil {
+		a.Extra = make(map[string]any, 1)
+	}
+	a.Extra[CodexFingerprintModeExtraKey] = string(mode)
+	return nil
+}
+
+// withExistingCodexFingerprintModeIfOmitted carries the account's effective
+// mode into a replacement extra map. It also canonicalizes malformed legacy
+// values to the defensive device default when an update omits the field.
+func withExistingCodexFingerprintModeIfOmitted(account *Account, extra map[string]any) map[string]any {
+	if account == nil || !account.IsOpenAIOAuth() || account.IsCredentialShadow() {
+		return extra
+	}
+	if _, provided := extra[CodexFingerprintModeExtraKey]; provided {
+		return extra
+	}
+	if extra == nil {
+		extra = make(map[string]any, 1)
+	}
+	extra[CodexFingerprintModeExtraKey] = string(account.GetCodexFingerprintMode())
+	return extra
+}
+
+func canonicalizeCodexFingerprintModeForOmittedExtraUpdate(account *Account) {
+	if account == nil || !account.IsOpenAIOAuth() || account.IsCredentialShadow() {
+		return
+	}
+	mode := account.GetCodexFingerprintMode()
+	if account.Extra == nil {
+		account.Extra = make(map[string]any, 1)
+	}
+	account.Extra[CodexFingerprintModeExtraKey] = string(mode)
+}
+
+func normalizeCodexFingerprintModeUpdateExtra(extra map[string]any) error {
+	if extra == nil {
+		return nil
+	}
+	raw, provided := extra[CodexFingerprintModeExtraKey]
+	if !provided {
+		return nil
+	}
+	mode, err := normalizeCodexFingerprintMode(raw)
+	if err != nil {
+		return err
+	}
+	extra[CodexFingerprintModeExtraKey] = string(mode)
+	return nil
+}
 
 // GetCodexFingerprintMode 从账号 extra JSON 读取指纹收敛模式。
 //
-// Plus 保持 session 为默认值：未设置、空值或非法值都回落到 session，只有
-// 管理员显式存储 off 才关闭收敛。API-key 账号始终为 off。
+// Device-only convergence is the defensive fallback for missing or malformed
+// legacy data. Canonical persistence stores every mode explicitly. Accounts
+// that do not own OpenAI OAuth credentials always remain off.
 func (a *Account) GetCodexFingerprintMode() codexFingerprintMode {
-	if a == nil || !a.IsOpenAIOAuth() {
+	if a == nil || !a.IsOpenAIOAuth() || a.IsCredentialShadow() {
 		return codexFingerprintOff
 	}
-	raw := strings.TrimSpace(a.GetExtraString(CodexFingerprintModeExtraKey))
-	switch codexFingerprintMode(raw) {
-	case codexFingerprintOff, codexFingerprintDevice, codexFingerprintSession, codexFingerprintFull:
-		return codexFingerprintMode(raw)
-	default:
-		return codexFingerprintSession
+	var raw any
+	if a.Extra != nil {
+		raw = a.Extra[CodexFingerprintModeExtraKey]
 	}
+	mode, err := normalizeCodexFingerprintMode(raw)
+	if err != nil {
+		return codexFingerprintDevice
+	}
+	return mode
 }
 
 // deriveStableUUIDv4 从种子确定性派生一个 UUIDv4 格式的字符串。

--- a/backend/internal/service/openai_codex_fingerprint_admin_test.go
+++ b/backend/internal/service/openai_codex_fingerprint_admin_test.go
@@ -1,0 +1,129 @@
+//go:build unit
+
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminServiceUpdateAccountPreservesExplicitCodexFingerprintModeWhenOmitted(t *testing.T) {
+	repo := &longContextBillingRepoStub{account: &Account{
+		ID:       1,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			CodexFingerprintModeExtraKey: "session",
+			"unrelated":                  true,
+		},
+	}}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	account, err := svc.UpdateAccount(context.Background(), 1, &UpdateAccountInput{
+		Extra: map[string]any{"unrelated": false},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "session", account.Extra[CodexFingerprintModeExtraKey])
+	require.Equal(t, false, account.Extra["unrelated"])
+}
+
+func TestAdminServiceUpdateAccountRepairsMalformedCodexFingerprintModeWhenFullExtraOmitsField(t *testing.T) {
+	repo := &longContextBillingRepoStub{account: &Account{
+		ID:       1,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			CodexFingerprintModeExtraKey: false,
+		},
+	}}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	account, err := svc.UpdateAccount(context.Background(), 1, &UpdateAccountInput{
+		Extra: map[string]any{},
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "device", account.Extra[CodexFingerprintModeExtraKey])
+}
+
+func TestAdminServiceUpdateAccountRepairsMalformedCodexFingerprintModeWhenExtraOmitted(t *testing.T) {
+	repo := &longContextBillingRepoStub{account: &Account{
+		ID:       1,
+		Name:     "before",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			CodexFingerprintModeExtraKey: false,
+		},
+	}}
+	svc := &adminServiceImpl{accountRepo: repo}
+
+	account, err := svc.UpdateAccount(context.Background(), 1, &UpdateAccountInput{
+		Name: "after",
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "after", account.Name)
+	require.Equal(t, "device", account.Extra[CodexFingerprintModeExtraKey])
+}
+
+func TestAccountServiceUpdatePreservesExplicitCodexFingerprintModeWhenReplacementOmitsField(t *testing.T) {
+	repo := &longContextBillingRepoStub{account: &Account{
+		ID:       1,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			CodexFingerprintModeExtraKey: "session",
+			"unrelated":                  true,
+		},
+	}}
+	svc := NewAccountService(repo, nil)
+	replacement := map[string]any{"unrelated": false}
+
+	account, err := svc.Update(context.Background(), 1, UpdateAccountRequest{Extra: &replacement})
+
+	require.NoError(t, err)
+	require.Equal(t, "session", account.Extra[CodexFingerprintModeExtraKey])
+	require.Equal(t, false, account.Extra["unrelated"])
+}
+
+func TestAccountServiceUpdateRepairsMalformedCodexFingerprintModeWhenReplacementOmitsField(t *testing.T) {
+	repo := &longContextBillingRepoStub{account: &Account{
+		ID:       1,
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			CodexFingerprintModeExtraKey: false,
+		},
+	}}
+	svc := NewAccountService(repo, nil)
+	replacement := map[string]any{}
+
+	account, err := svc.Update(context.Background(), 1, UpdateAccountRequest{Extra: &replacement})
+
+	require.NoError(t, err)
+	require.Equal(t, "device", account.Extra[CodexFingerprintModeExtraKey])
+}
+
+func TestAccountServiceUpdateRepairsMalformedCodexFingerprintModeWhenExtraOmitted(t *testing.T) {
+	repo := &longContextBillingRepoStub{account: &Account{
+		ID:       1,
+		Name:     "before",
+		Platform: PlatformOpenAI,
+		Type:     AccountTypeOAuth,
+		Extra: map[string]any{
+			CodexFingerprintModeExtraKey: false,
+		},
+	}}
+	svc := NewAccountService(repo, nil)
+	name := "after"
+
+	account, err := svc.Update(context.Background(), 1, UpdateAccountRequest{Name: &name})
+
+	require.NoError(t, err)
+	require.Equal(t, "after", account.Name)
+	require.Equal(t, "device", account.Extra[CodexFingerprintModeExtraKey])
+}

--- a/backend/internal/service/openai_codex_fingerprint_test.go
+++ b/backend/internal/service/openai_codex_fingerprint_test.go
@@ -47,6 +47,9 @@ func TestDeriveStableUUIDv4_ValidFormat(t *testing.T) {
 // --- GetCodexFingerprintMode ---
 
 func TestGetCodexFingerprintMode(t *testing.T) {
+	parentID := int64(9)
+	shadow := newTestOAuthAccount(10, map[string]any{CodexFingerprintModeExtraKey: "session"})
+	shadow.ParentAccountID = &parentID
 	tests := []struct {
 		name     string
 		account  *Account
@@ -54,10 +57,12 @@ func TestGetCodexFingerprintMode(t *testing.T) {
 	}{
 		{"nil 账号", nil, codexFingerprintOff},
 		{"非 OAuth 账号", &Account{Platform: PlatformOpenAI, Type: "api_key"}, codexFingerprintOff},
-		{"无 extra 默认 session", newTestOAuthAccount(1, nil), codexFingerprintSession},
-		{"空值默认 session", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: ""}), codexFingerprintSession},
-		{"空白值默认 session", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: "  "}), codexFingerprintSession},
-		{"非法值默认 session", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: "invalid"}), codexFingerprintSession},
+		{"影子账号不持有模式", shadow, codexFingerprintOff},
+		{"无 extra 默认 device", newTestOAuthAccount(1, nil), codexFingerprintDevice},
+		{"空值默认 device", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: ""}), codexFingerprintDevice},
+		{"空白值默认 device", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: "  "}), codexFingerprintDevice},
+		{"非法值默认 device", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: "invalid"}), codexFingerprintDevice},
+		{"错误类型默认 device", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: true}), codexFingerprintDevice},
 		{"显式 off", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: "off"}), codexFingerprintOff},
 		{"device", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: "device"}), codexFingerprintDevice},
 		{"session", newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: "session"}), codexFingerprintSession},
@@ -68,6 +73,84 @@ func TestGetCodexFingerprintMode(t *testing.T) {
 			assert.Equal(t, tt.expected, tt.account.GetCodexFingerprintMode())
 		})
 	}
+}
+
+func TestNormalizeCodexFingerprintMode(t *testing.T) {
+	t.Run("missing becomes explicit device", func(t *testing.T) {
+		account := newTestOAuthAccount(1, nil)
+		require.NoError(t, account.NormalizeCodexFingerprintMode())
+		assert.Equal(t, "device", account.Extra[CodexFingerprintModeExtraKey])
+	})
+
+	t.Run("valid mode is trimmed and retained", func(t *testing.T) {
+		account := newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: " session "})
+		require.NoError(t, account.NormalizeCodexFingerprintMode())
+		assert.Equal(t, "session", account.Extra[CodexFingerprintModeExtraKey])
+	})
+
+	t.Run("invalid explicit value is rejected", func(t *testing.T) {
+		account := newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: "invalid"})
+		err := account.NormalizeCodexFingerprintMode()
+		require.ErrorContains(t, err, "codex_fingerprint_mode must be one of")
+	})
+
+	t.Run("credential shadow remains unset", func(t *testing.T) {
+		parentID := int64(9)
+		account := newTestOAuthAccount(1, nil)
+		account.ParentAccountID = &parentID
+		require.NoError(t, account.NormalizeCodexFingerprintMode())
+		assert.Nil(t, account.Extra)
+	})
+
+	t.Run("non OAuth account drops the inapplicable mode", func(t *testing.T) {
+		account := &Account{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeAPIKey,
+			Extra:    map[string]any{CodexFingerprintModeExtraKey: "device"},
+		}
+		require.NoError(t, account.NormalizeCodexFingerprintMode())
+		assert.NotContains(t, account.Extra, CodexFingerprintModeExtraKey)
+	})
+}
+
+func TestNormalizeCodexFingerprintModeUpdateExtra(t *testing.T) {
+	t.Run("null becomes explicit device", func(t *testing.T) {
+		extra := map[string]any{CodexFingerprintModeExtraKey: nil}
+		require.NoError(t, normalizeCodexFingerprintModeUpdateExtra(extra))
+		assert.Equal(t, "device", extra[CodexFingerprintModeExtraKey])
+	})
+
+	t.Run("explicit session remains session", func(t *testing.T) {
+		extra := map[string]any{CodexFingerprintModeExtraKey: "session"}
+		require.NoError(t, normalizeCodexFingerprintModeUpdateExtra(extra))
+		assert.Equal(t, "session", extra[CodexFingerprintModeExtraKey])
+	})
+
+	t.Run("invalid explicit value is rejected", func(t *testing.T) {
+		extra := map[string]any{CodexFingerprintModeExtraKey: "invalid"}
+		err := normalizeCodexFingerprintModeUpdateExtra(extra)
+		require.ErrorContains(t, err, "codex_fingerprint_mode must be one of")
+	})
+}
+
+func TestBuildAccountForCreatePersistsExplicitCodexFingerprintMode(t *testing.T) {
+	t.Run("missing defaults to device", func(t *testing.T) {
+		account, err := buildAccountForCreate(&CreateAccountInput{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+		}, nil)
+		require.NoError(t, err)
+		assert.Equal(t, "device", account.Extra[CodexFingerprintModeExtraKey])
+	})
+
+	t.Run("explicit session is retained", func(t *testing.T) {
+		account, err := buildAccountForCreate(&CreateAccountInput{
+			Platform: PlatformOpenAI,
+			Type:     AccountTypeOAuth,
+		}, map[string]any{CodexFingerprintModeExtraKey: "session"})
+		require.NoError(t, err)
+		assert.Equal(t, "session", account.Extra[CodexFingerprintModeExtraKey])
+	})
 }
 
 // --- resolveConvergedInstallationID ---
@@ -120,15 +203,15 @@ func TestResolveCodexFingerprintIDsFromRequest_ExplicitOff(t *testing.T) {
 	assert.Nil(t, ids, "显式 off 模式应返回 nil")
 }
 
-func TestResolveCodexFingerprintIDsFromRequest_DefaultIsSession(t *testing.T) {
+func TestResolveCodexFingerprintIDsFromRequest_DefaultIsDevice(t *testing.T) {
 	account := newTestOAuthAccount(1, nil)
 	ids := resolveCodexFingerprintIDsFromRequest(account, nil)
 	require.NotNil(t, ids)
-	assert.Equal(t, codexFingerprintSession, ids.mode)
+	assert.Equal(t, codexFingerprintDevice, ids.mode)
 }
 
-// 管理员显式 opt-in 的账号行为不变。
-func TestResolveCodexFingerprintIDsFromRequest_ExplicitOptInHonored(t *testing.T) {
+// Every explicit convergence mode remains effective.
+func TestResolveCodexFingerprintIDsFromRequest_ExplicitModesHonored(t *testing.T) {
 	for _, mode := range []string{"device", "session", "full"} {
 		t.Run(mode, func(t *testing.T) {
 			account := newTestOAuthAccount(1, map[string]any{CodexFingerprintModeExtraKey: mode})

--- a/backend/internal/service/openai_oauth_passthrough_test.go
+++ b/backend/internal/service/openai_oauth_passthrough_test.go
@@ -211,6 +211,9 @@ func TestOpenAIGatewayService_OAuthMessagesBridgeDoesNotInjectDefaultInstruction
 			"access_token":       "oauth-token",
 			"chatgpt_account_id": "chatgpt-acc",
 		},
+		Extra: map[string]any{
+			CodexFingerprintModeExtraKey: string(codexFingerprintSession),
+		},
 		Status:      StatusActive,
 		Schedulable: true,
 	}

--- a/backend/migrations/224_backfill_codex_fingerprint_mode.sql
+++ b/backend/migrations/224_backfill_codex_fingerprint_mode.sql
@@ -1,0 +1,114 @@
+CREATE OR REPLACE FUNCTION public.enforce_codex_fingerprint_mode_extra()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+DECLARE
+    incoming_mode TEXT;
+    previous_mode TEXT;
+BEGIN
+    IF NEW.platform IS DISTINCT FROM 'openai'
+        OR NEW.type IS DISTINCT FROM 'oauth'
+        OR NEW.parent_account_id IS NOT NULL THEN
+        NEW.extra := COALESCE(NEW.extra, '{}'::jsonb) - 'codex_fingerprint_mode';
+        RETURN NEW;
+    END IF;
+
+    NEW.extra := COALESCE(NEW.extra, '{}'::jsonb);
+    IF jsonb_typeof(NEW.extra->'codex_fingerprint_mode') = 'string' THEN
+        incoming_mode := btrim(NEW.extra->>'codex_fingerprint_mode');
+    END IF;
+
+    IF incoming_mode IN ('off', 'device', 'session', 'full') THEN
+        NEW.extra := jsonb_set(
+            NEW.extra,
+            '{codex_fingerprint_mode}',
+            to_jsonb(incoming_mode),
+            true
+        );
+        RETURN NEW;
+    END IF;
+
+    IF NEW.extra ? 'codex_fingerprint_mode'
+        AND (
+            NEW.extra->'codex_fingerprint_mode' = 'null'::jsonb
+            OR (
+                jsonb_typeof(NEW.extra->'codex_fingerprint_mode') = 'string'
+                AND COALESCE(incoming_mode, '') = ''
+            )
+        ) THEN
+        NEW.extra := jsonb_set(
+            NEW.extra,
+            '{codex_fingerprint_mode}',
+            '"device"'::jsonb,
+            true
+        );
+        RETURN NEW;
+    END IF;
+
+    IF NEW.extra ? 'codex_fingerprint_mode' THEN
+        RAISE EXCEPTION 'codex_fingerprint_mode must be one of off, device, session, full'
+            USING ERRCODE = '22023';
+    END IF;
+
+    IF TG_OP = 'UPDATE'
+        AND OLD.platform = 'openai'
+        AND OLD.type = 'oauth'
+        AND OLD.parent_account_id IS NULL
+        AND jsonb_typeof(OLD.extra->'codex_fingerprint_mode') = 'string' THEN
+        previous_mode := btrim(OLD.extra->>'codex_fingerprint_mode');
+    END IF;
+
+    IF previous_mode IS NULL
+        OR previous_mode NOT IN ('off', 'device', 'session', 'full') THEN
+        previous_mode := 'device';
+    END IF;
+    NEW.extra := jsonb_set(
+        NEW.extra,
+        '{codex_fingerprint_mode}',
+        to_jsonb(previous_mode),
+        true
+    );
+    RETURN NEW;
+END;
+$$;
+
+UPDATE accounts
+SET extra = COALESCE(extra, '{}'::jsonb) - 'codex_fingerprint_mode'
+WHERE (
+    platform IS DISTINCT FROM 'openai'
+    OR type IS DISTINCT FROM 'oauth'
+    OR parent_account_id IS NOT NULL
+)
+  AND COALESCE(extra, '{}'::jsonb) ? 'codex_fingerprint_mode';
+
+UPDATE accounts
+SET extra = jsonb_set(
+    COALESCE(extra, '{}'::jsonb),
+    '{codex_fingerprint_mode}',
+    to_jsonb(
+        CASE
+            WHEN jsonb_typeof(extra->'codex_fingerprint_mode') = 'string'
+                AND btrim(extra->>'codex_fingerprint_mode') IN ('off', 'device', 'session', 'full')
+                THEN btrim(extra->>'codex_fingerprint_mode')
+            ELSE 'device'
+        END
+    ),
+    true
+)
+WHERE platform = 'openai'
+  AND type = 'oauth'
+  AND parent_account_id IS NULL
+  AND extra->>'codex_fingerprint_mode' IS DISTINCT FROM
+      CASE
+          WHEN jsonb_typeof(extra->'codex_fingerprint_mode') = 'string'
+              AND btrim(extra->>'codex_fingerprint_mode') IN ('off', 'device', 'session', 'full')
+              THEN btrim(extra->>'codex_fingerprint_mode')
+          ELSE 'device'
+      END;
+
+DROP TRIGGER IF EXISTS accounts_enforce_codex_fingerprint_mode_extra ON accounts;
+CREATE TRIGGER accounts_enforce_codex_fingerprint_mode_extra
+BEFORE INSERT OR UPDATE OF platform, type, extra, parent_account_id
+ON accounts
+FOR EACH ROW
+EXECUTE FUNCTION public.enforce_codex_fingerprint_mode_extra();

--- a/backend/migrations/codex_fingerprint_mode_migration_test.go
+++ b/backend/migrations/codex_fingerprint_mode_migration_test.go
@@ -1,0 +1,21 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestMigration224BackfillsAndEnforcesExplicitCodexFingerprintMode(t *testing.T) {
+	content, err := FS.ReadFile("224_backfill_codex_fingerprint_mode.sql")
+	require.NoError(t, err)
+
+	sql := string(content)
+	require.Contains(t, sql, "parent_account_id IS NULL")
+	require.Contains(t, sql, "type = 'oauth'")
+	require.Contains(t, sql, "ELSE 'device'")
+	require.Contains(t, sql, "codex_fingerprint_mode")
+	require.Contains(t, sql, "BEFORE INSERT OR UPDATE")
+	require.Contains(t, sql, "CREATE TRIGGER")
+	require.Contains(t, sql, "must be one of off, device, session, full")
+}

--- a/docs/protocols/CODEX_CLIENT_PROFILES.md
+++ b/docs/protocols/CODEX_CLIENT_PROFILES.md
@@ -106,6 +106,25 @@ fingerprint rules, and fingerprint-bypass option do not affect authorization.
 `gateway.force_codex_cli` is not an identity source and cannot bypass inbound
 access control or replace the selected outbound identity.
 
+## Outbound fingerprint convergence
+
+Every credential-owning OpenAI OAuth account stores an explicit
+`extra.codex_fingerprint_mode`. New accounts default to `device`; missing,
+empty, null, or malformed legacy values are normalized to `device`. API-key,
+setup-token, and credential-shadow accounts do not own this setting.
+
+| Mode | Upstream-visible identity behavior |
+| --- | --- |
+| `off` | Preserve client device, session, and thread identifiers. |
+| `device` (default) | Converge only the installation identifier to an account-level stable value; preserve each client's session and thread boundaries. |
+| `session` | Converge installation and session identifiers; derive a stable thread from the client-original session. |
+| `full` | Converge installation, session, and thread identifiers to account-level values. |
+
+Administration create, edit, bulk edit, Codex import, PAT creation, and CRS
+synchronization persist the selected value rather than representing a default
+by deleting the key. Native and legacy compact requests retain their existing
+fingerprint-convergence exclusions.
+
 ## Maintaining the profile registry
 
 Do not add a profile based only on a UI/product name or a community report.

--- a/frontend/src/components/account/BulkEditAccountModal.vue
+++ b/frontend/src/components/account/BulkEditAccountModal.vue
@@ -870,7 +870,7 @@
       </div>
 
       <!-- Codex 指纹收敛模式（仅 OpenAI OAuth） -->
-      <div v-if="allOpenAIOAuth" class="border-t border-gray-200 pt-4 dark:border-dark-600">
+      <div v-if="allOpenAIOAuthOnly" class="border-t border-gray-200 pt-4 dark:border-dark-600">
         <div class="mb-3 flex items-center justify-between">
           <label class="input-label mb-0">{{ t('admin.accounts.openai.codexFingerprintMode') }}</label>
           <input
@@ -1365,7 +1365,7 @@ const allOpenAIOAuth = computed(() => {
   )
 })
 
-// 严格 OAuth（不含 setup-token）：namespace 摊平兼容开关只对 OAuth 账号生效
+// 严格 OAuth（不含 setup-token）：仅真实 OAuth 账号可使用的控制项。
 const allOpenAIOAuthOnly = computed(() => {
   return (
     targetSelectedPlatforms.value.length === 1 &&
@@ -1490,7 +1490,7 @@ const upstreamBillingAutoProbeMode = ref<'enabled' | 'disabled'>('enabled')
 const codexCLIOnlyEnabled = ref(false)
 type CodexFingerprintMode = 'off' | 'device' | 'session' | 'full'
 const enableCodexFingerprintMode = ref(false)
-const codexFingerprintMode = ref<CodexFingerprintMode>('session')
+const codexFingerprintMode = ref<CodexFingerprintMode>('device')
 const codexFingerprintModeOptions = computed(() => [
   { value: 'off' as CodexFingerprintMode, label: t('admin.accounts.openai.codexFingerprintOff') },
   { value: 'device' as CodexFingerprintMode, label: t('admin.accounts.openai.codexFingerprintDevice') },
@@ -1771,14 +1771,9 @@ const buildUpdatePayload = (): Record<string, unknown> | null => {
     extra.codex_cli_only = codexCLIOnlyEnabled.value
   }
 
-  if (enableCodexFingerprintMode.value) {
+  if (enableCodexFingerprintMode.value && allOpenAIOAuthOnly.value) {
     const extra = ensureExtra()
-    // Bulk JSONB updates merge keys, so null is the repository's delete sentinel.
-    if (codexFingerprintMode.value !== 'session') {
-      extra.codex_fingerprint_mode = codexFingerprintMode.value
-    } else {
-      extra.codex_fingerprint_mode = null
-    }
+    extra.codex_fingerprint_mode = codexFingerprintMode.value
   }
 
   if (enableOpenAICompactMode.value) {
@@ -2025,7 +2020,7 @@ watch(
       enableUpstreamBillingAutoProbe.value = false
       enableCodexCLIOnly.value = false
       enableCodexFingerprintMode.value = false
-      codexFingerprintMode.value = 'session'
+      codexFingerprintMode.value = 'device'
       enableOpenAICompactMode.value = false
       enableOpenAICompactModelMapping.value = false
       enableRpmLimit.value = false

--- a/frontend/src/components/account/CreateAccountModal.vue
+++ b/frontend/src/components/account/CreateAccountModal.vue
@@ -3027,7 +3027,7 @@
 
       <!-- Codex 指纹收敛模式（仅 OpenAI OAuth） -->
       <div
-        v-if="form.platform === 'openai' && accountCategory === 'oauth-based'"
+        v-if="form.platform === 'openai' && form.type === 'oauth'"
         class="border-t border-gray-200 pt-4 dark:border-dark-600"
       >
         <div class="flex items-center justify-between gap-4">
@@ -3877,7 +3877,7 @@ const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
 type CodexFingerprintMode = 'off' | 'device' | 'session' | 'full'
-const codexFingerprintMode = ref<CodexFingerprintMode>('session')
+const codexFingerprintMode = ref<CodexFingerprintMode>('device')
 const codexFingerprintModeOptions = computed(() => [
   { value: 'off' as CodexFingerprintMode, label: t('admin.accounts.openai.codexFingerprintOff') },
   { value: 'device' as CodexFingerprintMode, label: t('admin.accounts.openai.codexFingerprintDevice') },
@@ -4762,7 +4762,7 @@ const resetForm = () => {
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   codexCLIOnlyEnabled.value = false
-  codexFingerprintMode.value = 'session'
+  codexFingerprintMode.value = 'device'
   anthropicPassthroughEnabled.value = false
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
   webSearchEmulationMode.value = 'default'
@@ -4862,7 +4862,7 @@ const buildOpenAIExtra = (base?: Record<string, unknown>): Record<string, unknow
   delete extra.codex_cli_only_allowed_clients
   // The retired app-server exception must never be persisted by newly created accounts.
   delete extra.codex_cli_only_allow_app_server
-  if (codexFingerprintMode.value !== 'session') {
+  if (form.type === 'oauth') {
     extra.codex_fingerprint_mode = codexFingerprintMode.value
   } else {
     delete extra.codex_fingerprint_mode

--- a/frontend/src/components/account/EditAccountModal.vue
+++ b/frontend/src/components/account/EditAccountModal.vue
@@ -2025,7 +2025,7 @@
 
       <!-- Codex 指纹收敛模式（仅 OpenAI OAuth） -->
       <div
-        v-if="account?.platform === 'openai' && account?.type === 'oauth'"
+        v-if="account?.platform === 'openai' && account?.type === 'oauth' && !isSparkShadow"
         class="border-t border-gray-200 pt-4 dark:border-dark-600"
       >
         <div class="flex items-center justify-between gap-4">
@@ -3002,7 +3002,7 @@ const openaiOAuthResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF
 const openaiAPIKeyResponsesWebSocketV2Mode = ref<OpenAIWSMode>(OPENAI_WS_MODE_OFF)
 const codexCLIOnlyEnabled = ref(false)
 type CodexFingerprintMode = 'off' | 'device' | 'session' | 'full'
-const codexFingerprintMode = ref<CodexFingerprintMode>('session')
+const codexFingerprintMode = ref<CodexFingerprintMode>('device')
 type CodexImageToolMode = 'inherit' | 'enabled' | 'disabled' | 'block'
 const codexImageToolMode = ref<CodexImageToolMode>('inherit')
 type AnthropicAPIKeyAuthScheme = 'x_api_key' | 'authorization_bearer'
@@ -3472,7 +3472,7 @@ const syncFormFromAccount = (newAccount: Account | null) => {
   openaiOAuthResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   openaiAPIKeyResponsesWebSocketV2Mode.value = OPENAI_WS_MODE_OFF
   codexCLIOnlyEnabled.value = false
-  codexFingerprintMode.value = 'session'
+  codexFingerprintMode.value = 'device'
   codexImageToolMode.value = 'inherit'
   anthropicPassthroughEnabled.value = false
   anthropicAPIKeyAuthScheme.value = 'x_api_key'
@@ -3526,10 +3526,10 @@ const syncFormFromAccount = (newAccount: Account | null) => {
     }
     if (newAccount.type === 'oauth') {
       const fpMode = extra?.codex_fingerprint_mode as string | undefined
-      // Missing or invalid values use the Plus session default.
+      // Missing or invalid legacy values use the device-only default.
       codexFingerprintMode.value = (['off', 'device', 'session', 'full'].includes(fpMode || '')
         ? fpMode as CodexFingerprintMode
-        : 'session')
+        : 'device')
     }
     const credentials = newAccount.credentials as Record<string, unknown> | undefined
 		openaiAccountUserAgent.value = !isSparkShadow.value && typeof credentials?.user_agent === 'string'
@@ -4891,13 +4891,11 @@ const handleSubmit = async () => {
         delete newExtra.codex_cli_only_allow_app_server
       }
 
-      // session is represented by an absent key; the other modes are explicit.
-      if (props.account.type === 'oauth') {
-        if (codexFingerprintMode.value !== 'session') {
-          newExtra.codex_fingerprint_mode = codexFingerprintMode.value
-        } else {
-          delete newExtra.codex_fingerprint_mode
-        }
+      // Every mode is persisted explicitly so account behavior is version-independent.
+      if (props.account.type === 'oauth' && !isSparkShadow.value) {
+        newExtra.codex_fingerprint_mode = codexFingerprintMode.value
+      } else {
+        delete newExtra.codex_fingerprint_mode
       }
 
       updatePayload.extra = newExtra

--- a/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/BulkEditAccountModal.spec.ts
@@ -345,7 +345,7 @@ describe('BulkEditAccountModal', () => {
     })
   })
 
-  it('批量编辑默认使用 session 并提交删键标记', async () => {
+  it('批量编辑默认显式持久化 device 指纹模式', async () => {
     const wrapper = mountModal({
       selectedPlatforms: ['openai'],
       selectedTypes: ['oauth']
@@ -354,14 +354,14 @@ describe('BulkEditAccountModal', () => {
     expect(
       wrapper.get<HTMLSelectElement>('[data-testid="bulk-codex-fingerprint-mode-select"]').element
         .value
-    ).toBe('session')
+    ).toBe('device')
     await wrapper.get('[data-testid="bulk-codex-fingerprint-mode-enabled"]').setValue(true)
     await wrapper.get('#bulk-edit-account-form').trigger('submit.prevent')
     await flushPromises()
 
     expect(adminAPI.accounts.bulkUpdate).toHaveBeenCalledWith([1, 2], {
       extra: {
-        codex_fingerprint_mode: null
+        codex_fingerprint_mode: 'device'
       }
     })
   })
@@ -382,6 +382,17 @@ describe('BulkEditAccountModal', () => {
         codex_fingerprint_mode: 'off'
       }
     })
+  })
+
+  it('OpenAI setup-token 批量编辑不显示 Codex 指纹模式', () => {
+    const wrapper = mountModal({
+      selectedPlatforms: ['openai'],
+      selectedTypes: ['setup-token']
+    })
+
+    expect(wrapper.find('[data-testid="bulk-codex-fingerprint-mode-enabled"]').exists()).toBe(
+      false
+    )
   })
 
   it('OpenAI API Key 批量编辑应提交 API Key 专属 WS mode 字段', async () => {

--- a/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/CreateAccountModal.spec.ts
@@ -185,6 +185,7 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
 
     expect(createAccountMock).toHaveBeenCalledTimes(1)
     expect(createAccountMock.mock.calls[0]?.[0]?.extra?.openai_long_context_billing_enabled).toBe(false)
+    expect(createAccountMock.mock.calls[0]?.[0]?.extra?.codex_fingerprint_mode).toBeUndefined()
   })
 
   // namespace 摊平是仅 OAuth 的兼容开关：API Key 走 chat completions 回退桥时由桥自行摊平
@@ -318,22 +319,22 @@ describe('CreateAccountModal OpenAI long-context billing', () => {
     expect(importCodexSessionMock.mock.calls[0]?.[0]?.extra?.openai_long_context_billing_enabled).toBeUndefined()
   })
 
-  it('uses implicit session fingerprint convergence for new Codex imports', async () => {
+  it('persists the explicit device fingerprint default for new Codex imports', async () => {
     const wrapper = mountModal()
     await selectButtonByText(wrapper, 'OpenAI')
 
     const mode = wrapper.get<HTMLSelectElement>(
       '[data-testid="create-codex-fingerprint-mode-select"]'
     )
-    expect(mode.element.value).toBe('session')
+    expect(mode.element.value).toBe('device')
 
     await wrapper.get('form#create-account-form input[type="text"]').setValue('Codex import')
     await wrapper.get('form#create-account-form').trigger('submit.prevent')
     await wrapper.get('[data-testid="import-codex-session"]').trigger('click')
     await flushPromises()
 
-    expect(importCodexSessionMock.mock.calls[0]?.[0]?.extra).not.toHaveProperty(
-      'codex_fingerprint_mode'
+    expect(importCodexSessionMock.mock.calls[0]?.[0]?.extra?.codex_fingerprint_mode).toBe(
+      'device'
     )
   })
 

--- a/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
+++ b/frontend/src/components/account/__tests__/EditAccountModal.spec.ts
@@ -461,7 +461,7 @@ describe('EditAccountModal', () => {
   it.each([
     ['missing', {}],
     ['invalid', { codex_fingerprint_mode: 'invalid' }],
-  ])('normalizes %s Codex fingerprint mode to implicit session', async (_name, extra) => {
+  ])('normalizes %s Codex fingerprint mode to explicit device', async (_name, extra) => {
     const account = buildAccount()
     account.type = 'oauth'
     account.extra = extra
@@ -472,14 +472,12 @@ describe('EditAccountModal', () => {
 
     const wrapper = mountModal(account)
     const mode = wrapper.get<HTMLSelectElement>('[data-testid="edit-codex-fingerprint-mode-select"]')
-    expect(mode.element.value).toBe('session')
+    expect(mode.element.value).toBe('device')
 
     await wrapper.get('form#edit-account-form').trigger('submit.prevent')
 
     expect(updateAccountMock).toHaveBeenCalledTimes(1)
-    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty(
-      'codex_fingerprint_mode'
-    )
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.codex_fingerprint_mode).toBe('device')
   })
 
   it('persists explicit off when editing an OAuth account', async () => {
@@ -496,6 +494,23 @@ describe('EditAccountModal', () => {
 
     expect(updateAccountMock).toHaveBeenCalledTimes(1)
     expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.codex_fingerprint_mode).toBe('off')
+  })
+
+  it('persists explicit session when editing an OAuth account', async () => {
+    const account = buildAccount()
+    account.type = 'oauth'
+    account.extra = { codex_fingerprint_mode: 'device' }
+    updateAccountMock.mockReset()
+    checkMixedChannelRiskMock.mockReset()
+    checkMixedChannelRiskMock.mockResolvedValue({ has_risk: false })
+    updateAccountMock.mockResolvedValue(account)
+
+    const wrapper = mountModal(account)
+    await wrapper.get('[data-testid="edit-codex-fingerprint-mode-select"]').setValue('session')
+    await wrapper.get('form#edit-account-form').trigger('submit.prevent')
+
+    expect(updateAccountMock).toHaveBeenCalledTimes(1)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra?.codex_fingerprint_mode).toBe('session')
   })
 
   it('hides the Codex namespace flatten toggle for non-OAuth OpenAI accounts', async () => {
@@ -543,6 +558,8 @@ describe('EditAccountModal', () => {
     expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty(
       'openai_long_context_billing_enabled'
     )
+    expect(wrapper.find('[data-testid="edit-codex-fingerprint-mode-select"]').exists()).toBe(false)
+    expect(updateAccountMock.mock.calls[0]?.[1]?.extra).not.toHaveProperty('codex_fingerprint_mode')
   })
 
   it('preserves an explicit OpenAI long-context billing opt-out', async () => {

--- a/frontend/src/i18n/locales/en/admin/accounts.ts
+++ b/frontend/src/i18n/locales/en/admin/accounts.ts
@@ -579,10 +579,10 @@ export default {
         codexCLIOnlyDesc:
           'Only applies to OpenAI OAuth. When enabled, only verified Codex request profiles are allowed, including the underlying transport identities shared by official CLI, App, and IDE surfaces. Request headers are spoofable: this does not attest a client binary or by itself determine account sharing.',
         codexFingerprintMode: 'Codex fingerprint convergence',
-        codexFingerprintModeDesc: 'When multiple users share the same OAuth account, converge device/session identifiers to account-level stable values to reduce upstream-visible device and session count. Session convergence is the default; choose Off to pass client identifiers through unchanged.',
+        codexFingerprintModeDesc: 'When multiple users share the same OAuth account, converge client identifiers to account-level stable values. By default, only the device identifier is converged and each client keeps an independent session; choose Off to pass client identifiers through unchanged.',
         codexFingerprintOff: 'Off (passthrough)',
-        codexFingerprintDevice: 'Device only',
-        codexFingerprintSession: 'Device + Session (default)',
+        codexFingerprintDevice: 'Device only (default)',
+        codexFingerprintSession: 'Device + Session',
         codexFingerprintFull: 'Full convergence',
         codexImageTool: 'Codex image bridge policy',
         codexImageToolDesc:

--- a/frontend/src/i18n/locales/zh/admin/accounts.ts
+++ b/frontend/src/i18n/locales/zh/admin/accounts.ts
@@ -650,10 +650,10 @@ export default {
         codexCLIOnly: '仅允许 Codex 官方客户端档案',
         codexCLIOnlyDesc: '仅对 OpenAI OAuth 生效。开启后仅允许已验证的 Codex 请求档案（包括官方 CLI、App 与 IDE 所共享的底层传输身份）；请求头特征可被伪造，不能证明客户端二进制官方性，也不能单独判断账号分享。',
         codexFingerprintMode: 'Codex 指纹收敛',
-        codexFingerprintModeDesc: '多人共享同一 OAuth 账号时，将各用户的设备/会话标识收敛为账号级恒定值，减少上游可见的设备数和会话数。默认使用会话级收敛；选择“关闭”可原样透传客户端标识。',
+        codexFingerprintModeDesc: '多人共享同一 OAuth 账号时，将客户端标识收敛为账号级恒定值。默认仅收敛设备标识并保留各客户端的独立会话；选择“关闭”可原样透传客户端标识。',
         codexFingerprintOff: '关闭（透传）',
-        codexFingerprintDevice: '仅设备',
-        codexFingerprintSession: '设备+会话（默认）',
+        codexFingerprintDevice: '仅设备（默认）',
+        codexFingerprintSession: '设备+会话',
         codexFingerprintFull: '完全收敛',
         codexImageTool: 'Codex 图片桥接策略',
         codexImageToolDesc:

--- a/openspec/changes/default-codex-fingerprint-to-device/design.md
+++ b/openspec/changes/default-codex-fingerprint-to-device/design.md
@@ -1,0 +1,37 @@
+## Decision
+
+`codex_fingerprint_mode` is a required persisted property of every real OpenAI
+OAuth credential account. Its canonical values are `off`, `device`, `session`,
+and `full`; `device` is the creation default.
+
+Application persistence normalizes account objects before repository writes so
+API responses and exports immediately expose the canonical value. A database
+trigger enforces the same invariant for CRS, mixed-version, and direct SQL
+writes. Runtime forwarding retains a pure-read `device` fallback for malformed
+legacy state and never repairs data on the request hot path.
+
+## Write Semantics
+
+- Inserts with a missing, null, or empty mode store `device`.
+- Valid strings are trimmed and stored explicitly.
+- For real OpenAI OAuth accounts, unknown strings and non-string values are
+  rejected by normal application writes.
+- An update that omits the key preserves a valid existing value. If neither the
+  new nor old row has a valid value, it stores `device`.
+- Frontend create, edit, and enabled bulk controls always submit the selected
+  value. They no longer use deletion or JSON null to represent a default.
+
+## Migration
+
+Migration `224_backfill_codex_fingerprint_mode.sql` canonicalizes all real
+OpenAI OAuth credential accounts. Missing, null, empty, and invalid modes become
+`device`; valid modes are trimmed and preserved. The migration removes the
+inapplicable key from Spark credential shadows and non-OAuth accounts.
+
+## Alternatives Rejected
+
+Keeping an absent key as the default representation saves a few JSON bytes but
+continues coupling account behavior to code-version defaults. Repairing missing
+values during request forwarding would add database side effects and cache
+coordination to a high-frequency path. Frontend-only normalization would miss
+Codex imports, PAT creation, CRS synchronization, and direct API writers.

--- a/openspec/changes/default-codex-fingerprint-to-device/proposal.md
+++ b/openspec/changes/default-codex-fingerprint-to-device/proposal.md
@@ -1,0 +1,37 @@
+## Why
+
+Codex fingerprint convergence currently treats an absent
+`codex_fingerprint_mode` as `session`. That makes persisted account behavior
+depend on the application version's implicit default and prevents exports,
+audits, and synchronization paths from showing the administrator's effective
+choice.
+
+The safer default is device-only convergence: one account-level installation
+identity while each client retains its own session and thread boundaries.
+
+## What Changes
+
+- Make `device` the default Codex fingerprint convergence mode for real OpenAI
+  OAuth credential accounts.
+- Persist every selected mode explicitly, including `device` and `session`.
+- Backfill missing, empty, null, or invalid stored modes to `device` and enforce
+  an explicit valid value for future writes.
+- Keep runtime reads defensive by treating malformed legacy data as `device`
+  without writing from request-forwarding paths.
+- Align create, edit, bulk edit, Codex import/PAT, CRS synchronization, locale
+  text, and tests with the new invariant.
+
+## Compatibility
+
+Existing real OpenAI OAuth accounts without a valid explicit mode currently
+behave as `session`; the migration intentionally changes them to `device`.
+Existing explicit `off`, `device`, `session`, and `full` choices are preserved.
+API-key, setup-token, and credential-shadow accounts remain outside this
+setting.
+
+## Impact
+
+- Affected capability: `codex-fingerprint-convergence`.
+- Affected data: `accounts.extra.codex_fingerprint_mode`.
+- Affected code: account persistence and synchronization, Codex outbound
+  fingerprint resolution, account administration UI, locales, and tests.

--- a/openspec/changes/default-codex-fingerprint-to-device/specs/codex-fingerprint-convergence/spec.md
+++ b/openspec/changes/default-codex-fingerprint-to-device/specs/codex-fingerprint-convergence/spec.md
@@ -1,0 +1,46 @@
+## RENAMED Requirements
+
+- FROM: `### Requirement: OAuth fingerprint convergence defaults to session`
+- TO: `### Requirement: OAuth fingerprint convergence defaults to device and is explicit`
+
+## MODIFIED Requirements
+
+### Requirement: OAuth fingerprint convergence defaults to device and is explicit
+
+A real OpenAI OAuth credential account SHALL persist exactly one valid
+`codex_fingerprint_mode`: `off`, `device`, `session`, or `full`. New accounts
+and legacy accounts with a missing, null, empty, or invalid mode SHALL use and
+persist `device`. API-key, setup-token, and credential-shadow accounts SHALL
+remain outside this setting.
+
+#### Scenario: A new OAuth account omits the mode
+
+- **WHEN** any supported account creation or synchronization path creates a
+  real OpenAI OAuth credential account without `codex_fingerprint_mode`
+- **THEN** persistence SHALL store `codex_fingerprint_mode` as `device`
+- **THEN** the returned and subsequently exported account SHALL expose `device`
+
+#### Scenario: Administrator saves a mode
+
+- **WHEN** the administrator selects `off`, `device`, `session`, or `full`
+- **THEN** create, edit, and enabled bulk controls SHALL submit that exact value
+- **THEN** persistence SHALL retain that value instead of deleting the key
+
+#### Scenario: Existing account has no valid stored mode
+
+- **WHEN** the migration observes a real OpenAI OAuth credential account with a
+  missing, null, empty, or invalid mode
+- **THEN** it SHALL store `device`
+- **THEN** runtime forwarding SHALL use device-only convergence
+
+#### Scenario: Runtime observes malformed legacy state
+
+- **WHEN** forwarding observes a missing or invalid mode despite persistence
+  enforcement
+- **THEN** it SHALL use `device` without writing to the database
+
+#### Scenario: Writer submits an invalid explicit mode
+
+- **WHEN** an application writer submits an unknown non-empty string or a
+  non-string value for a real OpenAI OAuth credential account
+- **THEN** the write SHALL be rejected

--- a/openspec/changes/default-codex-fingerprint-to-device/tasks.md
+++ b/openspec/changes/default-codex-fingerprint-to-device/tasks.md
@@ -1,0 +1,18 @@
+## 1. Contract and persistence
+
+- [x] 1.1 Specify explicit mode persistence and the `device` default.
+- [x] 1.2 Add application-level normalization for account writes.
+- [x] 1.3 Backfill legacy rows and enforce the database write invariant.
+
+## 2. Administration UI
+
+- [x] 2.1 Make create, edit, and bulk controls default to and submit `device`.
+- [x] 2.2 Update English and Chinese labels and descriptions.
+
+## 3. Verification
+
+- [x] 3.1 Cover runtime fallback, persistence normalization, and migration behavior.
+- [x] 3.2 Cover create, edit, and bulk payload semantics.
+- [x] 3.3 Run focused frontend, locale, type, lint, and migration filename checks.
+- [ ] 3.4 Run backend Go formatting, unit tests, and migration integration tests
+  when the required Go 1.26.6 and PostgreSQL toolchain is available.


### PR DESCRIPTION
## Summary

Submit `28-selected-model-is-at-capacity` after the repository local-validation gate.

## Validation

- Platform-container validation matrix passed.

<!-- sub2api-submit-pr: {"base":"9cb7e1228d682aad7843fc430b01e505f657996d","head":"1fecf57305e64a177ec0e8df72b9458cbbdc5169"} -->
