### PR TITLE
fix: restore direct-user content moderation scope

### DIFF
--- a/backend/internal/auditcontent/extract.go
+++ b/backend/internal/auditcontent/extract.go
@@ -1570,7 +1570,7 @@ func appendImageData(document *Document, value map[string]any, role string, sour
 func appendImage(document *Document, value, role string, source Source, current, controlled bool) {
 	value = strings.TrimSpace(value)
 	lower := strings.ToLower(value)
-	if value == "" || !(strings.HasPrefix(lower, "data:image/") || strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")) {
+	if value == "" || !strings.HasPrefix(lower, "data:image/") && !strings.HasPrefix(lower, "http://") && !strings.HasPrefix(lower, "https://") {
 		return
 	}
 	document.ContentBearing = true

--- a/backend/internal/auditcontent/extract.go
+++ b/backend/internal/auditcontent/extract.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io"
 	"sort"
 	"strings"
@@ -22,6 +23,8 @@ const (
 	SourceSearchQuery    Source = "search_query"
 	SourceEmbeddingInput Source = "embedding_input"
 	SourceMediaPrompt    Source = "media_prompt"
+	SourcePromptVariable Source = "prompt_variable"
+	SourceReasoning      Source = "reasoning"
 )
 
 type Segment struct {
@@ -32,8 +35,17 @@ type Segment struct {
 	ClientControlled bool
 }
 
+type Image struct {
+	URL              string
+	Role             string
+	Source           Source
+	Current          bool
+	ClientControlled bool
+}
+
 type Document struct {
 	Segments       []Segment
+	Images         []Image
 	ContentBearing bool
 	Incomplete     bool
 }
@@ -102,6 +114,21 @@ func normalizeDocument(document *Document) {
 		}
 	}
 	document.Segments = out
+	images := make([]Image, 0, len(document.Images))
+	seenImages := make(map[string]struct{}, len(document.Images))
+	for _, image := range document.Images {
+		image.URL = strings.TrimSpace(image.URL)
+		image.Role = strings.ToLower(strings.TrimSpace(image.Role))
+		key := image.URL + "\x00" + image.Role + "\x00" + string(image.Source) + fmt.Sprintf("\x00%t\x00%t", image.Current, image.ClientControlled)
+		if image.URL != "" {
+			if _, duplicate := seenImages[key]; duplicate {
+				continue
+			}
+			seenImages[key] = struct{}{}
+			images = append(images, image)
+		}
+	}
+	document.Images = images
 }
 
 func extractDefault(document *Document, root map[string]any) {
@@ -180,7 +207,7 @@ func extractChat(document *Document, root map[string]any) {
 		}
 		if refusal, exists := message["refusal"]; exists {
 			markContentBearing(document, refusal)
-			appendStructured(document, refusal, role, source, current, controlled)
+			appendStructured(document, refusal, "assistant", SourceMessage, current, controlled)
 		}
 		appendChatToolCalls(document, message, role, current)
 		markUnknownNonEmptyFields(document, message, "role", "content", "name", "tool_call_id", "tool_calls", "function_call", "refusal", "audio")
@@ -302,12 +329,13 @@ func appendAnthropicContent(document *Document, value any, role string, current 
 				markIncompleteContent(document)
 				return
 			}
-			appendStructured(document, thinking, role, SourceMessage, current, true)
+			appendStructured(document, thinking, "assistant", SourceReasoning, current, true)
 			markUnknownNonEmptyFields(document, typed, "type", "thinking", "signature")
 		case typeName == "redacted_thinking":
 			markUnknownNonEmptyFields(document, typed, "type", "data")
 			return
 		case typeName == "image" || typeName == "image_url" || typeName == "input_image":
+			appendImageValues(document, typed, role, SourceMessage, current, true, true)
 			if text, exists := typed["text"]; exists {
 				markContentBearing(document, text)
 				appendStructured(document, text, role, SourceMessage, current, true)
@@ -319,11 +347,16 @@ func appendAnthropicContent(document *Document, value any, role string, current 
 			markUnknownNonEmptyFields(document, typed, "type", "source", "image_url", "url", "text", "content", "cache_control")
 			return
 		default:
+			contentRole := role
+			if typeName == "output_text" {
+				contentRole = "assistant"
+			}
+			appendImageValues(document, typed, contentRole, SourceMessage, current, true, false)
 			if text, ok := typed["text"].(string); ok {
-				appendText(document, text, role, SourceMessage, current, true)
+				appendText(document, text, contentRole, SourceMessage, current, true)
 			}
 			if content, exists := typed["content"]; exists {
-				appendAnthropicContent(document, content, role, current)
+				appendAnthropicContent(document, content, contentRole, current)
 			}
 			if typeName == "" || typeName == "text" || typeName == "input_text" || typeName == "output_text" {
 				markUnknownNonEmptyFields(document, typed, "type", "text", "content", "citations", "cache_control")
@@ -480,7 +513,7 @@ func appendResponsesPrompt(document *Document, value any) {
 		document.ContentBearing = true
 		switch typed := value.(type) {
 		case string:
-			appendText(document, typed, "user", SourceMessage, true, true)
+			appendText(document, typed, "user", SourcePromptVariable, true, true)
 		case map[string]any:
 			typeName := normalizedType(typed["type"])
 			switch typeName {
@@ -489,13 +522,14 @@ func appendResponsesPrompt(document *Document, value any) {
 				if !exists {
 					markIncompleteContent(document)
 				} else {
-					appendStructured(document, text, "user", SourceMessage, true, true)
+					appendStructured(document, text, "user", SourcePromptVariable, true, true)
 				}
 				markUnknownNonEmptyFields(document, typed, "type", "text")
 			case "image", "image_url", "input_image", "input_file", "file":
-				// Reusable prompt variables can contain media. The legacy
-				// moderation path extracts images separately; encoded media is
-				// never persisted as prompt text.
+				appendImageValues(document, typed, "user", SourcePromptVariable, true, true, true)
+				// Reusable prompt variables can contain media. Canonical image
+				// attribution keeps it available to Prompt Audit without treating
+				// it as a direct-user Content Moderation input.
 				markUnknownNonEmptyFields(document, typed, "type", "image_url", "url", "file_id", "file_url", "file_data", "filename", "detail", "source", "data", "media_type", "mime_type")
 			default:
 				markIncompleteContent(document)
@@ -668,7 +702,7 @@ func appendResponsesItem(document *Document, value any, current bool) {
 		case "mcp_approval_response":
 			if reason, exists := typed["reason"]; exists {
 				markContentBearing(document, reason)
-				appendStructured(document, reason, roleOr(role, "user"), SourceMessage, current, true)
+				appendStructured(document, reason, roleOr(role, "user"), SourceToolOutput, current, true)
 			}
 			markUnknownNonEmptyFields(document, typed, "type", "id", "approval_request_id", "approve", "reason")
 			return
@@ -725,7 +759,7 @@ func appendResponsesItem(document *Document, value any, current bool) {
 			for _, key := range []string{"summary", "content", "text"} {
 				if payload, exists := typed[key]; exists {
 					markContentBearing(document, payload)
-					appendContent(document, payload, roleOr(role, "assistant"), SourceMessage, current, true)
+					appendContent(document, payload, "assistant", SourceReasoning, current, true)
 				}
 			}
 			markUnknownNonEmptyFields(document, typed, "type", "id", "status", "summary", "content", "text", "encrypted_content")
@@ -747,7 +781,7 @@ func appendResponsesItem(document *Document, value any, current bool) {
 				markIncompleteContent(document)
 			} else {
 				markContentBearing(document, refusal)
-				appendStructured(document, refusal, role, SourceMessage, current, true)
+				appendStructured(document, refusal, "assistant", SourceMessage, current, true)
 			}
 			markUnknownNonEmptyFields(document, typed, "type", "refusal")
 			return
@@ -762,6 +796,9 @@ func appendResponsesItem(document *Document, value any, current bool) {
 			if _, hasText := typed["text"]; !hasText && responsesItemRequiresExtraction(typeName, role, typed) {
 				markIncompleteContent(document)
 			}
+		}
+		if typeName == "output_text" {
+			role = "assistant"
 		}
 		controlled := true
 		source := SourceMessage
@@ -1174,14 +1211,21 @@ func appendGeminiParts(document *Document, value any, role string, source Source
 			continue
 		}
 		recognized := false
+		hasFunctionCall := false
+		hasFunctionResponse := false
 		if text, exists := part["text"]; exists {
 			recognized = true
 			markContentBearing(document, text)
-			appendStructured(document, text, role, source, current, true)
+			textRole, textSource := role, source
+			if thought, _ := part["thought"].(bool); thought {
+				textRole, textSource = "model", SourceReasoning
+			}
+			appendStructured(document, text, textRole, textSource, current, true)
 		}
 		for _, key := range []string{"functionCall", "function_call"} {
 			if call, ok := part[key].(map[string]any); ok {
 				recognized = true
+				hasFunctionCall = true
 				arguments := firstExisting(call, "args", "arguments")
 				if arguments == nil {
 					markIncompleteContent(document)
@@ -1194,6 +1238,7 @@ func appendGeminiParts(document *Document, value any, role string, source Source
 		for _, key := range []string{"functionResponse", "function_response"} {
 			if response, ok := part[key].(map[string]any); ok {
 				recognized = true
+				hasFunctionResponse = true
 				output, exists := response["response"]
 				if !exists {
 					markIncompleteContent(document)
@@ -1203,6 +1248,17 @@ func appendGeminiParts(document *Document, value any, role string, source Source
 				appendToolOutput(document, output, current)
 			}
 		}
+		imageRole, imageSource := role, source
+		if thought, _ := part["thought"].(bool); thought {
+			imageRole, imageSource = "model", SourceReasoning
+		}
+		switch {
+		case hasFunctionResponse:
+			imageRole, imageSource = "tool", SourceToolOutput
+		case hasFunctionCall:
+			imageRole, imageSource = roleOr(role, "model"), SourceToolCall
+		}
+		appendImageValues(document, part, imageRole, imageSource, current, true, false)
 		if !recognized && !isGeminiMediaPart(part) && hasNonEmptyValue(part) {
 			markIncompleteContent(document)
 		}
@@ -1245,6 +1301,9 @@ func appendGeminiInstances(document *Document, value any) {
 }
 
 func extractMediaPrompts(document *Document, root map[string]any) {
+	for _, key := range []string{"image", "images", "mask", "reference_images"} {
+		appendImageValues(document, root[key], "user", SourceMediaPrompt, true, true, true)
+	}
 	seen := make(map[string]struct{})
 	var walk func(any, string)
 	walk = func(value any, key string) {
@@ -1371,6 +1430,16 @@ func appendContent(document *Document, value any, role string, source Source, cu
 	case map[string]any:
 		before := len(document.Segments)
 		typeName := normalizedType(typed["type"])
+		contentRole, contentSource := role, source
+		switch typeName {
+		case "output_text":
+			contentRole = "assistant"
+		case "summary_text":
+			contentRole, contentSource = "assistant", SourceReasoning
+		}
+		if typeName != "tool_result" {
+			appendImageValues(document, typed, contentRole, contentSource, current, controlled, false)
+		}
 		if isImageType(typeName) && !hasAnyKey(typed, "text", "content") {
 			markUnknownNonEmptyFields(document, typed, "type", "image_url", "url", "file_id", "detail", "source", "data", "media_type", "mime_type", "filename")
 			return
@@ -1389,16 +1458,24 @@ func appendContent(document *Document, value any, role string, source Source, cu
 			return
 		}
 		if text, exists := typed["text"]; exists {
-			appendStructured(document, text, role, source, current, controlled)
+			appendStructured(document, text, contentRole, contentSource, current, controlled)
 		}
 		if content, exists := typed["content"]; exists {
-			appendContent(document, content, role, source, current, controlled)
+			appendContent(document, content, contentRole, contentSource, current, controlled)
+		}
+		if typeName == "refusal" {
+			refusal, exists := typed["refusal"]
+			if !exists {
+				markIncompleteContent(document)
+			} else {
+				appendStructured(document, refusal, "assistant", contentSource, current, controlled)
+			}
 		}
 		if len(document.Segments) == before && contentRequiresExtraction(typed) {
 			markIncompleteContent(document)
 		}
 		switch typeName {
-		case "", "text", "input_text", "output_text":
+		case "", "text", "input_text", "output_text", "summary_text":
 			markUnknownNonEmptyFields(document, typed, "type", "text", "content", "annotations", "logprobs")
 		case "message":
 			markUnknownNonEmptyFields(document, typed, "type", "id", "status", "role", "content", "text")
@@ -1420,6 +1497,7 @@ func appendStructured(document *Document, value any, role string, source Source,
 	if value == nil {
 		return
 	}
+	appendImageValues(document, value, role, source, current, controlled, false)
 	if text, ok := value.(string); ok {
 		if looksLikeEncodedMediaPayload(text) {
 			return
@@ -1446,6 +1524,87 @@ func appendText(document *Document, text, role string, source Source, current, c
 	document.Segments = append(document.Segments, Segment{
 		Text: text, Role: role, Source: source, Current: current, ClientControlled: controlled,
 	})
+}
+
+func appendImageValues(document *Document, value any, role string, source Source, current, controlled, mediaContext bool) {
+	if document == nil || value == nil {
+		return
+	}
+	switch typed := value.(type) {
+	case string:
+		candidate := strings.TrimSpace(typed)
+		if mediaContext || strings.HasPrefix(strings.ToLower(candidate), "data:image/") {
+			appendImage(document, candidate, role, source, current, controlled)
+		}
+	case []any:
+		for _, item := range typed {
+			appendImageValues(document, item, role, source, current, controlled, mediaContext)
+		}
+	case map[string]any:
+		appendImageData(document, typed, role, source, current, controlled)
+		objectMedia := mediaContext || isImageMediaType(normalizedType(typed["type"]))
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, key := range keys {
+			childMedia := objectMedia || isImageValueField(key)
+			appendImageValues(document, typed[key], role, source, current, controlled, childMedia)
+		}
+	}
+}
+
+func appendImageData(document *Document, value map[string]any, role string, source Source, current, controlled bool) {
+	mimeType := firstString(value, "media_type", "mediaType", "mime_type", "mimeType")
+	if !strings.HasPrefix(strings.ToLower(strings.TrimSpace(mimeType)), "image/") {
+		return
+	}
+	data := firstString(value, "data", "base64")
+	if strings.TrimSpace(data) == "" {
+		return
+	}
+	appendImage(document, fmt.Sprintf("data:%s;base64,%s", strings.TrimSpace(mimeType), strings.TrimSpace(data)), role, source, current, controlled)
+}
+
+func appendImage(document *Document, value, role string, source Source, current, controlled bool) {
+	value = strings.TrimSpace(value)
+	lower := strings.ToLower(value)
+	if value == "" || !(strings.HasPrefix(lower, "data:image/") || strings.HasPrefix(lower, "http://") || strings.HasPrefix(lower, "https://")) {
+		return
+	}
+	document.ContentBearing = true
+	document.Images = append(document.Images, Image{
+		URL: value, Role: role, Source: source, Current: current, ClientControlled: controlled,
+	})
+}
+
+func firstString(values map[string]any, keys ...string) string {
+	for _, key := range keys {
+		if value, ok := values[key].(string); ok && strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func isImageMediaType(typeName string) bool {
+	switch typeName {
+	case "image", "image_url", "input_image", "output_image", "computer_screenshot":
+		return true
+	default:
+		return false
+	}
+}
+
+func isImageValueField(key string) bool {
+	normalized := strings.NewReplacer("_", "", "-", "").Replace(strings.ToLower(strings.TrimSpace(key)))
+	switch normalized {
+	case "image", "images", "imageurl", "screenshot", "partialscreenshot", "partialimage", "mask", "referenceimages", "inlinedata", "filedata", "fileuri":
+		return true
+	default:
+		return false
+	}
 }
 
 func normalizedRole(value any) string {

--- a/backend/internal/auditcontent/extract_test.go
+++ b/backend/internal/auditcontent/extract_test.go
@@ -175,6 +175,9 @@ func TestExtractResponsesReusablePromptVariables(t *testing.T) {
 	require.True(t, document.ContentBearing)
 	require.False(t, document.Incomplete)
 	require.Equal(t, []string{"variable text", "typed variable"}, segmentTexts(document.Segments))
+	require.Equal(t, []Source{SourcePromptVariable, SourcePromptVariable}, segmentSources(document.Segments))
+	require.Equal(t, []string{"https://example.test/image.png"}, imageURLs(document.Images))
+	require.Equal(t, SourcePromptVariable, document.Images[0].Source)
 }
 
 func TestExtractResponsesOfficialExtendedInputItems(t *testing.T) {
@@ -376,16 +379,59 @@ func TestExtractTreatsRecognizedMediaOnlyBlocksAsExplicitNoText(t *testing.T) {
 		protocol, body string
 	}{
 		{"openai_chat_completions", `{"messages":[{"role":"user","content":[{"type":"image_url","image_url":{"url":"https://example.test/a.png"}}]}]}`},
-		{"anthropic_messages", `{"messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64","data":"AAAA"}}]}]}`},
+		{"anthropic_messages", `{"messages":[{"role":"user","content":[{"type":"image","source":{"type":"base64","media_type":"image/png","data":"AAAA"}}]}]}`},
 		{"openai_responses", `{"input":[{"type":"message","role":"user","content":[{"type":"input_image","image_url":"https://example.test/a.png"}]}]}`},
 		{"gemini", `{"contents":[{"role":"user","parts":[{"inlineData":{"mimeType":"image/png","data":"AAAA"}}]}]}`},
 	}
 	for _, test := range tests {
 		document, err := Extract(test.protocol, []byte(test.body))
 		require.NoError(t, err)
-		require.False(t, document.ContentBearing)
+		require.True(t, document.ContentBearing)
 		require.Empty(t, document.Segments)
+		require.Len(t, document.Images, 1)
+		require.True(t, document.Images[0].Current)
+		require.Equal(t, "user", document.Images[0].Role)
 	}
+}
+
+func TestExtractLiveSessionInputCarriesCanonicalImage(t *testing.T) {
+	document, err := Extract("openai_live", []byte(`{"type":"session.update","session":{"input":[{"type":"message","role":"user","content":[{"type":"input_image","image_url":"https://example.test/live-session.png"}]}]}}`))
+	require.NoError(t, err)
+	require.False(t, document.Incomplete)
+	require.Equal(t, []string{"https://example.test/live-session.png"}, imageURLs(document.Images))
+	require.True(t, document.Images[0].Current)
+	require.Equal(t, SourceMessage, document.Images[0].Source)
+}
+
+func TestExtractKeepsReasoningSourceDistinctFromToolCalls(t *testing.T) {
+	document, err := Extract("anthropic_messages", []byte(`{"messages":[{"role":"assistant","content":[{"type":"thinking","thinking":"private reasoning"}]}]}`))
+	require.NoError(t, err)
+	require.False(t, document.Incomplete)
+	require.Equal(t, []string{"private reasoning"}, segmentTexts(document.Segments))
+	require.Equal(t, []Source{SourceReasoning}, segmentSources(document.Segments))
+}
+
+func TestExtractClassifiesResponsesAndGeminiModelOutput(t *testing.T) {
+	responses, err := Extract("openai_responses", []byte(`{"input":[
+		{"type":"reasoning","summary":[{"type":"summary_text","text":"reasoning summary"}]},
+		{"type":"message","content":[{"type":"output_text","text":"model output"},{"type":"refusal","refusal":"model refusal"}]},
+		{"type":"output_text","text":"direct output item"}
+	]}`))
+	require.NoError(t, err)
+	require.False(t, responses.Incomplete)
+	require.Equal(t, []string{"reasoning summary", "model output", "model refusal", "direct output item"}, segmentTexts(responses.Segments))
+	require.Equal(t, []Source{SourceReasoning, SourceMessage, SourceMessage, SourceMessage}, segmentSources(responses.Segments))
+	for _, segment := range responses.Segments {
+		require.Equal(t, "assistant", segment.Role)
+	}
+
+	gemini, err := Extract("gemini", []byte(`{"contents":[{"parts":[{"text":"private thought","thought":true},{"text":"direct user text"}]}]}`))
+	require.NoError(t, err)
+	require.False(t, gemini.Incomplete)
+	require.Equal(t, []string{"private thought", "direct user text"}, segmentTexts(gemini.Segments))
+	require.Equal(t, []Source{SourceReasoning, SourceMessage}, segmentSources(gemini.Segments))
+	require.Equal(t, "model", gemini.Segments[0].Role)
+	require.Empty(t, gemini.Segments[1].Role)
 }
 
 func TestExtractMediaTypeCannotSuppressPresentText(t *testing.T) {
@@ -431,6 +477,14 @@ func segmentSources(segments []Segment) []Source {
 	result := make([]Source, 0, len(segments))
 	for _, segment := range segments {
 		result = append(result, segment.Source)
+	}
+	return result
+}
+
+func imageURLs(images []Image) []string {
+	result := make([]string, 0, len(images))
+	for _, image := range images {
+		result = append(result, image.URL)
 	}
 	return result
 }

--- a/backend/internal/handler/security_audit_content_contract_test.go
+++ b/backend/internal/handler/security_audit_content_contract_test.go
@@ -9,7 +9,82 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSecurityAuditEnginesShareCanonicalContentCoverage(t *testing.T) {
+func TestContentModerationUsesLatestUserTextWithoutInstructionContext(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+		body     string
+		want     string
+		images   []string
+	}{
+		{
+			name: "responses latest user", protocol: service.ContentModerationProtocolOpenAIResponses,
+			body: `{"instructions":"audit instruction","tools":[{"type":"function","name":"lookup","description":"audit tool definition"}],` +
+				`"input":[{"type":"message","role":"user","content":"older prompt"},{"type":"message","role":"user","content":"你好"}]}`,
+			want: "你好",
+		},
+		{
+			name: "responses tool loop skipped", protocol: service.ContentModerationProtocolOpenAIResponses,
+			body: `{"input":[{"type":"message","role":"user","content":"older prompt"},{"type":"function_call_output","call_id":"call_1","output":"current tool result"}]}`,
+		},
+		{
+			name: "responses assistant item skipped", protocol: service.ContentModerationProtocolOpenAIResponses,
+			body: `{"input":[{"type":"message","role":"user","content":"older prompt"},{"type":"message","role":"assistant","content":"current assistant payload"}]}`,
+		},
+		{
+			name: "responses prompt variables skipped", protocol: service.ContentModerationProtocolOpenAIResponses,
+			body: `{"prompt":{"id":"pmpt_1","variables":{"plain":"reusable variable","image":{"type":"input_image","image_url":"https://example.test/prompt.png"}}}}`,
+		},
+		{
+			name: "nested websocket user", protocol: service.ContentModerationProtocolOpenAIResponses,
+			body: `{"type":"response.create","input":[],"response":{"input":[{"type":"message","role":"user","content":"nested content cannot be shadowed"}]}}`,
+			want: "nested content cannot be shadowed",
+		},
+		{
+			name: "chat latest user", protocol: service.ContentModerationProtocolOpenAIChat,
+			body: `{"messages":[{"role":"system","content":"chat system context"},{"role":"user","content":"你好"}]}`,
+			want: "你好",
+		},
+		{
+			name: "chat tool result skipped", protocol: service.ContentModerationProtocolOpenAIChat,
+			body: `{"messages":[{"role":"user","content":"older"},{"role":"tool","content":"chat tool result"}]}`,
+		},
+		{
+			name: "anthropic tool result skipped", protocol: service.ContentModerationProtocolAnthropicMessages,
+			body: `{"system":"anthropic instruction","messages":[{"role":"user","content":[{"type":"tool_result","content":{"safe":false}}]}]}`,
+		},
+		{
+			name: "gemini function response skipped", protocol: service.ContentModerationProtocolGemini,
+			body: `{"systemInstruction":{"parts":[{"text":"gemini instruction"}]},"contents":[{"role":"user","parts":[{"functionResponse":{"response":{"safe":false}}}]}]}`,
+		},
+		{
+			name: "live user image preserved", protocol: service.ContentModerationProtocolOpenAILive,
+			body:   `{"type":"conversation.item.create","item":{"type":"message","role":"user","content":[{"type":"input_image","image_url":"https://example.test/live.png"}]}}`,
+			images: []string{"https://example.test/live.png"},
+		},
+		{
+			name: "live session instructions skipped", protocol: service.ContentModerationProtocolOpenAILive,
+			body: `{"model":"gpt-live-test","instructions":"live instructions"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			legacy := service.ExtractContentModerationInput(test.protocol, []byte(test.body))
+			require.Equal(t, test.want, legacy.Text)
+			if len(test.images) == 0 {
+				require.Empty(t, legacy.Images)
+			} else {
+				require.Equal(t, test.images, legacy.Images)
+			}
+			require.NotContains(t, legacy.Text, "instruction")
+			require.NotContains(t, legacy.Text, "tool definition")
+			require.NotContains(t, legacy.Text, "system context")
+		})
+	}
+}
+
+func TestPromptAuditStillCoversInstructionsAndCurrentClientContent(t *testing.T) {
 	tests := []struct {
 		name     string
 		protocol string
@@ -17,65 +92,20 @@ func TestSecurityAuditEnginesShareCanonicalContentCoverage(t *testing.T) {
 		current  []string
 	}{
 		{
-			name: "responses function result", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"input":[{"type":"message","role":"user","content":"older prompt"},{"type":"function_call_output","call_id":"call_1","output":"current tool result"}]}`,
-			current: []string{"current tool result"},
-		},
-		{
 			name: "current assistant role plus context", protocol: service.ContentModerationProtocolOpenAIResponses,
 			body: `{"instructions":"audit instruction","tools":[{"type":"function","name":"lookup","description":"audit tool definition"}],` +
 				`"input":[{"type":"message","role":"user","content":"older prompt"},{"type":"message","role":"assistant","content":"current assistant payload"}]}`,
 			current: []string{"current assistant payload", "audit instruction", "audit tool definition"},
 		},
 		{
-			name: "responses custom and search results", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"input":[{"type":"custom_tool_call_output","output":{"status":"ok"}},{"type":"tool_search_output","output":"search evidence"}]}`,
-			current: []string{`{"status":"ok"}`, "search evidence"},
+			name: "responses function result", protocol: service.ContentModerationProtocolOpenAIResponses,
+			body:    `{"input":[{"type":"message","role":"user","content":"older prompt"},{"type":"function_call_output","call_id":"call_1","output":"current tool result"}]}`,
+			current: []string{"current tool result"},
 		},
 		{
 			name: "responses reusable prompt variables", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"prompt":{"id":"pmpt_1","variables":{"plain":"prompt variable","typed":{"type":"input_text","text":"typed variable"}}}}`,
-			current: []string{"prompt variable", "typed variable"},
-		},
-		{
-			name: "responses official shell outputs", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"input":[{"type":"local_shell_call_output","call_id":"l1","status":"completed","output":"local output"},{"type":"shell_call_output","call_id":"s1","status":"completed","output":[{"stdout":"shell output","stderr":"","outcome":{"type":"exit","exit_code":0}}]},{"type":"apply_patch_call_output","call_id":"p1","status":"failed","output":"patch output"}]}`,
-			current: []string{"local output", "shell output", "patch output"},
-		},
-		{
-			name: "responses official tool search result", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"input":[{"type":"tool_search_output","execution":"client","call_id":"t1","status":"completed","tools":[{"type":"function","name":"lookup","description":"dynamic tool definition"}]}]}`,
-			current: []string{`[{"description":"dynamic tool definition","name":"lookup","type":"function"}]`},
-		},
-		{
-			name: "responses mcp and programmatic tool calling", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"input":[{"type":"mcp_call","id":"m1","status":"completed","server_label":"docs","name":"lookup","arguments":"{\"q\":\"audit\"}","output":"mcp output","error":null},{"type":"program_output","call_id":"p1","status":"completed","result":"program output"}]}`,
-			current: []string{`{"q":"audit"}`, "mcp output", "program output"},
-		},
-		{
-			name: "responses mcp result", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"input":[{"type":"reasoning","encrypted_content":"gAAAAAB","summary":[]},{"type":"mcp_tool_call","arguments":{"q":"docs"}},{"type":"mcp_tool_call_output","output":{"result":"found"}}]}`,
-			current: []string{`{"result":"found"}`},
-		},
-		{
-			name: "nested websocket", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"type":"response.create","model":"gpt-test","response":{"input":"nested ws content"}}`,
-			current: []string{"nested ws content"},
-		},
-		{
-			name: "top-level input cannot shadow nested websocket", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"type":"response.create","input":[],"response":{"input":"nested content cannot be shadowed"}}`,
-			current: []string{"nested content cannot be shadowed"},
-		},
-		{
-			name: "alpha search", protocol: "openai_alpha_search",
-			body:    `{"commands":{"search_query":[{"q":"security query"}]},"input":[{"type":"message","role":"user","content":"recent search context"}]}`,
-			current: []string{"security query", "recent search context"},
-		},
-		{
-			name: "responses top-level type does not bypass HTTP content", protocol: service.ContentModerationProtocolOpenAIResponses,
-			body:    `{"type":"future.control","input":"typed HTTP content"}`,
-			current: []string{"typed HTTP content"},
+			body:    `{"prompt":{"id":"pmpt_1","variables":{"plain":"reusable variable","typed":{"type":"input_text","text":"typed variable"}}}}`,
+			current: []string{"reusable variable", "typed variable"},
 		},
 		{
 			name: "live initial session", protocol: service.ContentModerationProtocolOpenAILive,
@@ -85,47 +115,14 @@ func TestSecurityAuditEnginesShareCanonicalContentCoverage(t *testing.T) {
 			current: []string{"live instructions", "legacy transcription context", "current transcription context", "premium plan", "AC-42"},
 		},
 		{
-			name: "live sideband session update", protocol: "openai_live",
-			body:    `{"type":"session.update","session":{"instructions":"sideband instruction","tools":[{"name":"lookup","description":"sideband tool policy"}],"audio":{"input":{"transcription":{"model":"gpt-live-transcribe","prompt":"sideband transcription context"}}}}}`,
-			current: []string{"sideband instruction", "sideband tool policy", "sideband transcription context"},
-		},
-		{
-			name: "live sideband tool result", protocol: "openai_live",
-			body:    `{"type":"conversation.item.create","item":{"type":"function_call_output","output":"sideband tool result"}}`,
-			current: []string{"sideband tool result"},
-		},
-		{
-			name: "embeddings array", protocol: "openai_embeddings",
-			body:    `{"input":["embedding one","embedding two"]}`,
-			current: []string{"embedding one", "embedding two"},
-		},
-		{
-			name: "chat tool result", protocol: service.ContentModerationProtocolOpenAIChat,
-			body:    `{"messages":[{"role":"user","content":"older"},{"role":"tool","content":"chat tool result"}]}`,
-			current: []string{"chat tool result"},
-		},
-		{
 			name: "chat parallel structured tool results and system context", protocol: service.ContentModerationProtocolOpenAIChat,
 			body:    `{"messages":[{"role":"system","content":"chat system context"},{"role":"user","content":"older"},{"role":"assistant","tool_calls":[{"function":{"arguments":"{}"}}]},{"role":"tool","content":{"first":true}},{"role":"function","content":{"second":false}}]}`,
 			current: []string{`{"first":true}`, `{"second":false}`, "chat system context"},
-		},
-		{
-			name: "anthropic tool result", protocol: service.ContentModerationProtocolAnthropicMessages,
-			body:    `{"messages":[{"role":"user","content":[{"type":"tool_result","content":{"safe":false}}]}]}`,
-			current: []string{`{"safe":false}`},
-		},
-		{
-			name: "gemini function response", protocol: service.ContentModerationProtocolGemini,
-			body:    `{"contents":[{"role":"user","parts":[{"functionResponse":{"response":{"safe":false}}}]}]}`,
-			current: []string{`{"safe":false}`},
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			legacy := service.ExtractContentModerationInput(test.protocol, []byte(test.body))
-			require.NotEmpty(t, legacy.Text)
-
 			full, err := securityaudit.ExtractPromptSnapshot(securityaudit.Request{
 				Protocol: test.protocol,
 				Body:     []byte(test.body),
@@ -138,7 +135,6 @@ func TestSecurityAuditEnginesShareCanonicalContentCoverage(t *testing.T) {
 			require.NoError(t, err)
 
 			for _, expected := range test.current {
-				require.Contains(t, legacy.Text, expected)
 				require.Contains(t, full.ScanText, expected)
 				require.Contains(t, latest.ScanText, expected)
 			}

--- a/backend/internal/securityaudit/prompt_snapshot.go
+++ b/backend/internal/securityaudit/prompt_snapshot.go
@@ -58,7 +58,7 @@ func extractPromptSnapshot(req Request, latestTurnOnly bool) (PromptSnapshot, er
 		segments = blockingSegmentsLatestUserAndPreviousOutput(extracted)
 	}
 	if len(segments) == 0 {
-		if document.ContentBearing {
+		if document.ContentBearing && len(document.Images) == 0 {
 			return PromptSnapshot{}, ErrPromptContentExtract
 		}
 		return PromptSnapshot{}, ErrNoPromptText

--- a/backend/internal/service/content_moderation_input.go
+++ b/backend/internal/service/content_moderation_input.go
@@ -2,12 +2,10 @@ package service
 
 import (
 	"crypto/rand"
-	"fmt"
 	"math/big"
 	"strings"
 
 	"github.com/LuckyKuang/sub2api-plus/internal/auditcontent"
-	"github.com/tidwall/gjson"
 )
 
 func ExtractContentModerationText(protocol string, body []byte) string {
@@ -25,43 +23,20 @@ func extractContentModerationInput(protocol string, body []byte) (ContentModerat
 		return ContentModerationInput{}, false, err
 	}
 	var parts []string
-	for _, includeContext := range []bool{false, true} {
-		for _, segment := range document.Segments {
-			if !segment.Current || isModerationContextSegment(segment) != includeContext {
-				continue
-			}
-			if text := strings.TrimSpace(segment.Text); text != "" {
-				parts = append(parts, text)
-			}
+	for _, segment := range document.Segments {
+		if !isModerationDirectUser(protocol, segment.Role, segment.Source, segment.Current) {
+			continue
+		}
+		if text := moderationUserText(segment.Text); text != "" {
+			parts = append(parts, text)
 		}
 	}
 
-	var images []string
-	switch protocol {
-	case ContentModerationProtocolAnthropicMessages:
-		collectCurrentAnthropicImages(gjson.GetBytes(body, "messages"), &images)
-	case ContentModerationProtocolOpenAIChat:
-		collectCurrentChatImages(gjson.GetBytes(body, "messages"), &images)
-	case ContentModerationProtocolOpenAIResponses:
-		collectCurrentResponsesImages(gjson.GetBytes(body, "input"), &images)
-		collectCurrentResponsesImages(gjson.GetBytes(body, "response.input"), &images)
-		collectModerationImages(gjson.GetBytes(body, "item"), false, &images)
-		collectResponsesPromptImages(gjson.GetBytes(body, "prompt.variables"), &images)
-		collectResponsesPromptImages(gjson.GetBytes(body, "response.prompt.variables"), &images)
-		collectResponsesPromptImages(gjson.GetBytes(body, "session.prompt.variables"), &images)
-	case ContentModerationProtocolGemini:
-		collectCurrentGeminiImages(gjson.GetBytes(body, "contents"), &images)
-	case ContentModerationProtocolOpenAIImages:
-		collectModerationImages(gjson.GetBytes(body, "images"), true, &images)
-	default:
-		collectCurrentResponsesImages(gjson.GetBytes(body, "input"), &images)
-		collectCurrentResponsesImages(gjson.GetBytes(body, "response.input"), &images)
-		collectModerationImages(gjson.GetBytes(body, "item"), false, &images)
-		collectResponsesPromptImages(gjson.GetBytes(body, "prompt.variables"), &images)
-		collectResponsesPromptImages(gjson.GetBytes(body, "response.prompt.variables"), &images)
-		collectResponsesPromptImages(gjson.GetBytes(body, "session.prompt.variables"), &images)
-		collectCurrentChatImages(gjson.GetBytes(body, "messages"), &images)
-		collectCurrentGeminiImages(gjson.GetBytes(body, "contents"), &images)
+	images := make([]string, 0, len(document.Images))
+	for _, image := range document.Images {
+		if isModerationDirectUser(protocol, image.Role, image.Source, image.Current) {
+			images = append(images, image.URL)
+		}
 	}
 	out := ContentModerationInput{
 		Text:   normalizeContentModerationText(strings.Join(parts, "\n")),
@@ -71,195 +46,33 @@ func extractContentModerationInput(protocol string, body []byte) (ContentModerat
 	if document.Incomplete {
 		return out, true, auditcontent.ErrIncompleteContent
 	}
-	return out, document.ContentBearing || len(images) > 0, nil
+	return out, !out.IsEmpty(), nil
 }
 
-func isModerationContextSegment(segment auditcontent.Segment) bool {
-	return segment.Source == auditcontent.SourceInstruction || segment.Source == auditcontent.SourceToolDefinition
-}
-
-func collectCurrentChatImages(messages gjson.Result, images *[]string) {
-	if !messages.IsArray() {
-		return
+func isModerationDirectUser(protocol, role string, source auditcontent.Source, current bool) bool {
+	if !current {
+		return false
 	}
-	array := messages.Array()
-	if len(array) == 0 {
-		return
-	}
-	currentStart := len(array) - 1
-	if isChatModerationToolOutput(array[currentStart]) {
-		for currentStart > 0 && isChatModerationToolOutput(array[currentStart-1]) {
-			currentStart--
-		}
-	}
-	for _, message := range array[currentStart:] {
-		collectModerationImages(message.Get("content"), false, images)
-	}
-}
-
-func isChatModerationToolOutput(message gjson.Result) bool {
-	role := strings.ToLower(strings.TrimSpace(message.Get("role").String()))
-	return role == "tool" || role == "function"
-}
-
-func collectCurrentAnthropicImages(messages gjson.Result, images *[]string) {
-	if !messages.IsArray() {
-		return
-	}
-	array := messages.Array()
-	if len(array) == 0 {
-		return
-	}
-	collectModerationImages(array[len(array)-1].Get("content"), false, images)
-}
-
-func collectCurrentResponsesImages(input gjson.Result, images *[]string) {
-	switch {
-	case !input.Exists():
-		return
-	case input.IsArray():
-		array := input.Array()
-		if len(array) == 0 {
-			return
-		}
-		currentStart := len(array) - 1
-		if isResponsesModerationToolOutput(array[currentStart]) {
-			for currentStart > 0 && isResponsesModerationToolOutput(array[currentStart-1]) {
-				currentStart--
-			}
-		}
-		for _, item := range array[currentStart:] {
-			collectModerationImages(item, false, images)
-		}
-	case input.IsObject():
-		collectModerationImages(input, false, images)
-	}
-}
-
-func isResponsesModerationToolOutput(item gjson.Result) bool {
-	switch strings.ToLower(strings.TrimSpace(item.Get("type").String())) {
-	case "function_call_output", "custom_tool_call_output", "tool_search_output", "mcp_tool_call_output",
-		"local_shell_call_output", "shell_call_output", "apply_patch_call_output", "computer_call_output",
-		"program_output", "mcp_approval_response", "mcp_call":
-		return true
+	switch source {
+	case auditcontent.SourceMessage, auditcontent.SourceSearchQuery, auditcontent.SourceEmbeddingInput, auditcontent.SourceMediaPrompt:
 	default:
 		return false
 	}
-}
-
-func collectCurrentGeminiImages(contents gjson.Result, images *[]string) {
-	if !contents.IsArray() {
-		return
-	}
-	array := contents.Array()
-	if len(array) == 0 {
-		return
-	}
-	last := array[len(array)-1]
-	if arr := last.Get("parts"); arr.IsArray() {
-		arr.ForEach(func(_, part gjson.Result) bool {
-			addGeminiModerationImage(images, part)
-			collectModerationImages(part, false, images)
-			return true
-		})
-	}
-}
-
-func collectResponsesPromptImages(variables gjson.Result, images *[]string) {
-	if !variables.IsObject() {
-		return
-	}
-	variables.ForEach(func(_, value gjson.Result) bool {
-		collectModerationImages(value, false, images)
-		return true
-	})
-}
-
-func collectModerationImages(value gjson.Result, mediaContext bool, images *[]string) {
-	switch {
-	case !value.Exists():
-		return
-	case value.Type == gjson.String:
-		candidate := strings.TrimSpace(value.String())
-		if mediaContext || strings.HasPrefix(strings.ToLower(candidate), "data:image/") {
-			addModerationImage(images, candidate)
-		}
-	case value.IsArray():
-		value.ForEach(func(_, item gjson.Result) bool {
-			collectModerationImages(item, mediaContext, images)
-			return true
-		})
-	case value.IsObject():
-		typ := strings.ToLower(strings.TrimSpace(value.Get("type").String()))
-		addModerationImageData(images, value.Get("source.media_type").String(), value.Get("source.data").String())
-		addModerationImageData(images, value.Get("source.mediaType").String(), value.Get("source.data").String())
-		addModerationImageData(images, value.Get("media_type").String(), value.Get("data").String())
-		addModerationImageData(images, value.Get("mime_type").String(), value.Get("data").String())
-		addModerationImageData(images, value.Get("mimeType").String(), value.Get("data").String())
-		objectMedia := mediaContext || isModerationImageType(typ)
-		value.ForEach(func(key, child gjson.Result) bool {
-			childMedia := objectMedia || isModerationImageField(key.String())
-			collectModerationImages(child, childMedia, images)
-			return true
-		})
-	}
-}
-
-func isModerationImageType(typeName string) bool {
-	switch typeName {
-	case "image", "image_url", "input_image", "output_image", "computer_screenshot":
-		return true
+	role = strings.ToLower(strings.TrimSpace(role))
+	switch protocol {
+	case ContentModerationProtocolOpenAIResponses, ContentModerationProtocolOpenAILive, ContentModerationProtocolGemini:
+		return role == "user" || role == ""
 	default:
-		return false
+		return role == "user"
 	}
 }
 
-func isModerationImageField(key string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(key))
-	switch normalized {
-	case "image", "images", "image_url", "imageurl", "screenshot", "partial_image":
-		return true
-	default:
-		return false
+func moderationUserText(text string) string {
+	text = strings.TrimSpace(text)
+	if text == "" || strings.Contains(text, "<system-reminder>") {
+		return ""
 	}
-}
-
-func addGeminiModerationImage(images *[]string, part gjson.Result) {
-	if inlineData := part.Get("inline_data"); inlineData.IsObject() {
-		mimeType := strings.TrimSpace(inlineData.Get("mime_type").String())
-		data := strings.TrimSpace(inlineData.Get("data").String())
-		if mimeType != "" && data != "" {
-			addModerationImage(images, fmt.Sprintf("data:%s;base64,%s", mimeType, data))
-		}
-	}
-	if inlineData := part.Get("inlineData"); inlineData.IsObject() {
-		mimeType := strings.TrimSpace(inlineData.Get("mimeType").String())
-		data := strings.TrimSpace(inlineData.Get("data").String())
-		if mimeType != "" && data != "" {
-			addModerationImage(images, fmt.Sprintf("data:%s;base64,%s", mimeType, data))
-		}
-	}
-	addModerationImage(images, part.Get("file_data.file_uri").String())
-	addModerationImage(images, part.Get("fileData.fileUri").String())
-}
-
-func addModerationImageData(images *[]string, mimeType string, data string) {
-	mimeType = strings.TrimSpace(mimeType)
-	data = strings.TrimSpace(data)
-	if !strings.HasPrefix(strings.ToLower(mimeType), "image/") || data == "" {
-		return
-	}
-	addModerationImage(images, fmt.Sprintf("data:%s;base64,%s", mimeType, data))
-}
-
-func addModerationImage(images *[]string, image string) {
-	image = strings.TrimSpace(image)
-	if image == "" {
-		return
-	}
-	if strings.HasPrefix(image, "data:") || strings.HasPrefix(image, "http://") || strings.HasPrefix(image, "https://") {
-		*images = append(*images, image)
-	}
+	return text
 }
 
 func normalizeModerationImages(images []string) []string {

--- a/backend/internal/service/content_moderation_input_test.go
+++ b/backend/internal/service/content_moderation_input_test.go
@@ -1,15 +1,16 @@
 package service
 
 import (
-	"strings"
 	"testing"
 
+	"github.com/LuckyKuang/sub2api-plus/internal/auditcontent"
 	"github.com/stretchr/testify/require"
 )
 
-// Agent 工具循环只审核当前结果，不回溯重复审核历史用户消息。
+// 当数组末尾不是用户消息时（典型场景：Agent 工具循环结束于 tool/assistant），
+// 应直接跳过内容审核——不再把 system/tools/tool 回包送进 Moderations。
 
-func TestExtractContentModerationInput_AnthropicAgentToolLoopAuditsCurrentResult(t *testing.T) {
+func TestExtractContentModerationInput_AnthropicAgentToolLoopSkipsAudit(t *testing.T) {
 	body := []byte(`{
 		"messages": [
 			{"role":"user","content":"调用一下天气工具"},
@@ -20,7 +21,7 @@ func TestExtractContentModerationInput_AnthropicAgentToolLoopAuditsCurrentResult
 
 	input := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, body)
 
-	require.Equal(t, "晴 25 度", input.Text)
+	require.Empty(t, input.Text)
 	require.Empty(t, input.Images)
 }
 
@@ -64,7 +65,7 @@ func TestExtractContentModerationInput_AnthropicStreamResendExtractsResend(t *te
 	require.Equal(t, "重发", input.Text)
 }
 
-func TestExtractContentModerationInput_OpenAIChatAgentToolLoopAuditsCurrentResult(t *testing.T) {
+func TestExtractContentModerationInput_OpenAIChatAgentToolLoopSkipsAudit(t *testing.T) {
 	body := []byte(`{
 		"messages": [
 			{"role":"system","content":"sys"},
@@ -76,11 +77,11 @@ func TestExtractContentModerationInput_OpenAIChatAgentToolLoopAuditsCurrentResul
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIChat, body)
 
-	require.Equal(t, "[] sys", input.Text)
+	require.Empty(t, input.Text)
 	require.Empty(t, input.Images)
 }
 
-func TestExtractContentModerationInput_OpenAIChatAuditsParallelStructuredToolResults(t *testing.T) {
+func TestExtractContentModerationInput_OpenAIChatSkipsParallelStructuredToolResults(t *testing.T) {
 	body := []byte(`{
 		"messages": [
 			{"role":"system","content":"system context"},
@@ -93,7 +94,7 @@ func TestExtractContentModerationInput_OpenAIChatAuditsParallelStructuredToolRes
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIChat, body)
 
-	require.Equal(t, "{\"result\":\"first\"} {\"result\":\"second\"} system context", input.Text)
+	require.Empty(t, input.Text)
 	require.Empty(t, input.Images)
 }
 
@@ -111,7 +112,7 @@ func TestExtractContentModerationInput_OpenAIChatMultiTurnExtractsLatestUser(t *
 	require.Equal(t, "Q2", input.Text)
 }
 
-func TestExtractContentModerationInput_GeminiAgentToolLoopAuditsCurrentResult(t *testing.T) {
+func TestExtractContentModerationInput_GeminiAgentToolLoopSkipsAudit(t *testing.T) {
 	body := []byte(`{
 		"contents": [
 			{"role":"user","parts":[{"text":"查询天气"}]},
@@ -122,7 +123,7 @@ func TestExtractContentModerationInput_GeminiAgentToolLoopAuditsCurrentResult(t 
 
 	input := ExtractContentModerationInput(ContentModerationProtocolGemini, body)
 
-	require.JSONEq(t, `{"temp":25}`, input.Text)
+	require.Empty(t, input.Text)
 	require.Empty(t, input.Images)
 }
 
@@ -152,7 +153,7 @@ func TestExtractContentModerationInput_GeminiMultiTurnExtractsLatestUser(t *test
 	require.Equal(t, "Q2", input.Text)
 }
 
-func TestExtractContentModerationInput_ResponsesAgentToolLoopAuditsCurrentResult(t *testing.T) {
+func TestExtractContentModerationInput_ResponsesAgentToolLoopSkipsAudit(t *testing.T) {
 	body := []byte(`{
 		"input":[
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"运行测试"}]},
@@ -163,7 +164,7 @@ func TestExtractContentModerationInput_ResponsesAgentToolLoopAuditsCurrentResult
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
 
-	require.Equal(t, "all passed", input.Text)
+	require.Empty(t, input.Text)
 	require.Empty(t, input.Images)
 }
 
@@ -181,7 +182,7 @@ func TestExtractContentModerationInput_ResponsesLastUserMessageExtracted(t *test
 	require.Equal(t, "latest", input.Text)
 }
 
-func TestExtractContentModerationInput_ResponsesLastClientAssistantContentAudited(t *testing.T) {
+func TestExtractContentModerationInput_ResponsesLastAssistantSkipped(t *testing.T) {
 	body := []byte(`{
 		"input":[
 			{"type":"message","role":"user","content":[{"type":"input_text","text":"q1"}]},
@@ -191,7 +192,7 @@ func TestExtractContentModerationInput_ResponsesLastClientAssistantContentAudite
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
 
-	require.Equal(t, "a1", input.Text)
+	require.Empty(t, input.Text)
 	require.Empty(t, input.Images)
 }
 
@@ -211,21 +212,21 @@ func TestExtractContentModerationInput_ResponsesTopLevelInputCannotShadowNestedC
 	require.Equal(t, []string{"https://example.test/nested.png"}, input.Images)
 }
 
-func TestExtractContentModerationInput_AuditsCurrentContentBeforeContext(t *testing.T) {
+func TestExtractContentModerationInput_DoesNotAuditInstructionsOrToolDefinitions(t *testing.T) {
 	body := []byte(`{
 		"instructions":"<system-reminder>context must still be audited</system-reminder>",
 		"tools":[{"type":"function","name":"lookup","description":"tool definition policy"}],
-		"input":[{"type":"message","role":"assistant","content":"current assistant payload"}]
+		"input":[{"type":"message","role":"user","content":"你好"}]
 	}`)
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
 
-	require.True(t, strings.HasPrefix(input.Text, "current assistant payload"))
-	require.Contains(t, input.Text, "system-reminder")
-	require.Contains(t, input.Text, "tool definition policy")
+	require.Equal(t, "你好", input.Text)
+	require.NotContains(t, input.Text, "system-reminder")
+	require.NotContains(t, input.Text, "tool definition policy")
 }
 
-func TestExtractContentModerationInput_ChatCollectsImagesFromParallelToolResults(t *testing.T) {
+func TestExtractContentModerationInput_ChatDoesNotCollectImagesFromToolResults(t *testing.T) {
 	body := []byte(`{"messages":[
 		{"role":"user","content":"inspect"},
 		{"role":"tool","tool_call_id":"c1","content":{"image_url":"https://example.test/one.png"}},
@@ -234,10 +235,11 @@ func TestExtractContentModerationInput_ChatCollectsImagesFromParallelToolResults
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIChat, body)
 
-	require.Equal(t, []string{"https://example.test/one.png", "https://example.test/two.png"}, input.Images)
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
 }
 
-func TestExtractContentModerationInput_ResponsesCollectsImagesFromTrailingOfficialOutputs(t *testing.T) {
+func TestExtractContentModerationInput_ResponsesDoesNotCollectImagesFromTrailingOfficialOutputs(t *testing.T) {
 	body := []byte(`{"input":[
 		{"type":"message","role":"user","content":"inspect"},
 		{"type":"function_call_output","call_id":"c1","output":{"image_url":"https://example.test/tool.png"}},
@@ -246,24 +248,26 @@ func TestExtractContentModerationInput_ResponsesCollectsImagesFromTrailingOffici
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
 
-	require.Equal(t, []string{"https://example.test/tool.png", "https://example.test/screenshot.png"}, input.Images)
-	require.NotContains(t, input.Text, "example.test")
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
 }
 
-func TestExtractContentModerationInput_AnthropicCollectsNestedToolResultImage(t *testing.T) {
+func TestExtractContentModerationInput_AnthropicDoesNotCollectNestedToolResultImage(t *testing.T) {
 	body := []byte(`{"messages":[{"role":"user","content":[{"type":"tool_result","tool_use_id":"t1","content":[{"type":"image","source":{"type":"url","url":"https://example.test/result.png"}}]}]}]}`)
 
 	input := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, body)
 
-	require.Equal(t, []string{"https://example.test/result.png"}, input.Images)
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
 }
 
-func TestExtractContentModerationInput_ResponsesCollectsReusablePromptVariableImage(t *testing.T) {
-	body := []byte(`{"prompt":{"id":"pmpt_1","variables":{"photo":{"type":"input_image","image_url":"https://example.test/prompt.png"}}}}`)
+func TestExtractContentModerationInput_ResponsesDoesNotAuditReusablePromptVariables(t *testing.T) {
+	body := []byte(`{"prompt":{"id":"pmpt_1","variables":{"plain":"prompt variable","photo":{"type":"input_image","image_url":"https://example.test/prompt.png"}}}}`)
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
 
-	require.Equal(t, []string{"https://example.test/prompt.png"}, input.Images)
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
 }
 
 func TestExtractContentModerationInput_DoesNotTreatOrdinaryToolURLAsImage(t *testing.T) {
@@ -272,7 +276,7 @@ func TestExtractContentModerationInput_DoesNotTreatOrdinaryToolURLAsImage(t *tes
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
 
 	require.Empty(t, input.Images)
-	require.Contains(t, input.Text, "documentation_url")
+	require.Empty(t, input.Text)
 }
 
 func TestExtractContentModerationInput_LiveConversationItemPreservesImage(t *testing.T) {
@@ -281,4 +285,85 @@ func TestExtractContentModerationInput_LiveConversationItemPreservesImage(t *tes
 	input := ExtractContentModerationInput("openai_live", body)
 
 	require.Equal(t, []string{"https://example.test/live.png"}, input.Images)
+}
+
+func TestExtractContentModerationInput_LiveSessionInputPreservesImage(t *testing.T) {
+	body := []byte(`{"type":"session.update","session":{"input":[{"type":"message","role":"user","content":[{"type":"input_image","image_url":"https://example.test/live-session.png"}]}]}}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAILive, body)
+
+	require.Equal(t, []string{"https://example.test/live-session.png"}, input.Images)
+}
+
+func TestExtractContentModerationInput_AuditsDirectEmbeddingAndSearchInput(t *testing.T) {
+	embeddings := ExtractContentModerationInput("openai_embeddings", []byte(`{"input":["embedding one","embedding two"]}`))
+	require.Equal(t, "embedding one embedding two", embeddings.Text)
+
+	search := ExtractContentModerationInput("openai_alpha_search", []byte(`{"commands":{"search_query":[{"q":"security query"}]},"input":[{"type":"message","role":"user","content":"recent search context"}]}`))
+	require.Equal(t, "security query recent search context", search.Text)
+}
+
+func TestExtractContentModerationInput_AnthropicThinkingIsNotAudited(t *testing.T) {
+	body := []byte(`{"messages":[{"role":"user","content":[{"type":"thinking","thinking":"private reasoning about violence"},{"type":"text","text":"你好"}]}]}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, body)
+
+	require.Equal(t, "你好", input.Text)
+	require.NotContains(t, input.Text, "private reasoning")
+}
+
+func TestExtractContentModerationInput_ModelOutputFormsAreNotDirectUserInput(t *testing.T) {
+	responses := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, []byte(`{"input":[
+		{"type":"reasoning","summary":[{"type":"summary_text","text":"private reasoning"}]},
+		{"type":"message","content":[{"type":"output_text","text":"model output"},{"type":"refusal","refusal":"model refusal"}]},
+		{"type":"output_text","text":"direct output item"}
+	]}`))
+	require.Empty(t, responses.Text)
+	require.Empty(t, responses.Images)
+
+	gemini := ExtractContentModerationInput(ContentModerationProtocolGemini, []byte(`{"contents":[{"parts":[{"text":"private thought","thought":true},{"text":"你好"}]}]}`))
+	require.Equal(t, "你好", gemini.Text)
+	require.NotContains(t, gemini.Text, "private thought")
+
+	anthropic := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, []byte(`{"messages":[{"role":"user","content":[{"type":"output_text","text":"model output"},{"type":"text","text":"你好"}]}]}`))
+	require.Equal(t, "你好", anthropic.Text)
+	require.NotContains(t, anthropic.Text, "model output")
+}
+
+func TestExtractContentModerationInput_ResponsesStringInputIsAudited(t *testing.T) {
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, []byte(`{"input":"你好"}`))
+	require.Equal(t, "你好", input.Text)
+}
+
+func TestExtractContentModerationInput_UnknownSiblingFailsWithoutHidingLatestUser(t *testing.T) {
+	body := []byte(`{"input":[{"type":"message","role":"user","content":"你好","future_payload":"must not hide user text"}]}`)
+
+	input, contentBearing, err := extractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
+
+	require.ErrorIs(t, err, auditcontent.ErrIncompleteContent)
+	require.True(t, contentBearing)
+	require.Equal(t, "你好", input.Text)
+}
+
+func TestExtractContentModerationInput_RequiresExplicitUserRoleForChatAndAnthropic(t *testing.T) {
+	chat := ExtractContentModerationInput(ContentModerationProtocolOpenAIChat, []byte(`{"messages":[{"content":"roleless chat"}]}`))
+	require.Empty(t, chat.Text)
+
+	anthropic := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, []byte(`{"messages":[{"content":"roleless anthropic"}]}`))
+	require.Empty(t, anthropic.Text)
+
+	responses := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, []byte(`{"input":[{"type":"message","content":"roleless responses"}]}`))
+	require.Equal(t, "roleless responses", responses.Text)
+
+	gemini := ExtractContentModerationInput(ContentModerationProtocolGemini, []byte(`{"contents":[{"parts":[{"text":"roleless gemini"}]}]}`))
+	require.Equal(t, "roleless gemini", gemini.Text)
+}
+
+func TestExtractContentModerationInput_LiveSessionInstructionsAreNotAudited(t *testing.T) {
+	body := []byte(`{"model":"gpt-live-test","instructions":"live safety policy about violence"}`)
+
+	input := ExtractContentModerationInput(ContentModerationProtocolOpenAILive, body)
+
+	require.Empty(t, input.Text)
+	require.Empty(t, input.Images)
 }

--- a/backend/internal/service/content_moderation_test.go
+++ b/backend/internal/service/content_moderation_test.go
@@ -534,7 +534,7 @@ func TestContentModerationCheck_ContentBearingExtractionFailureIsModeAware(t *te
 			decision, err := svc.Check(context.Background(), ContentModerationCheckInput{
 				Protocol: ContentModerationProtocolOpenAIResponses,
 				Endpoint: "/v1/responses",
-				Body:     []byte(`{"input":[{"type":"local_shell_call","call_id":"c1","action":{"command":"pwd"},"future_payload":"missing adapter"}]}`),
+				Body:     []byte(`{"input":[{"type":"message","role":"user","content":"visible user text","future_payload":"missing adapter"}]}`),
 			})
 			require.NoError(t, err)
 			require.Equal(t, test.wantBlocked, decision.Blocked)
@@ -584,6 +584,31 @@ func TestContentModerationCheck_SessionUnknownSiblingFailsClosed(t *testing.T) {
 			require.Equal(t, ContentModerationErrorCodeUnavailable, decision.ErrorCode)
 		})
 	}
+}
+
+func TestContentModerationCheck_InvalidJSONStillFailsClosedInPreBlock(t *testing.T) {
+	cfg := defaultContentModerationConfig()
+	cfg.Enabled = true
+	cfg.Mode = ContentModerationModePreBlock
+	rawCfg, err := json.Marshal(cfg)
+	require.NoError(t, err)
+	svc := NewContentModerationService(
+		&contentModerationTestSettingRepo{values: map[string]string{
+			SettingKeyRiskControlEnabled:      "true",
+			SettingKeyContentModerationConfig: string(rawCfg),
+		}},
+		&contentModerationTestRepo{}, nil, nil, nil, nil, nil, nil,
+	)
+
+	decision, err := svc.Check(context.Background(), ContentModerationCheckInput{
+		Protocol: ContentModerationProtocolOpenAIResponses,
+		Endpoint: "/v1/responses",
+		Body:     []byte(`{"input":`),
+	})
+	require.NoError(t, err)
+	require.True(t, decision.Blocked)
+	require.Equal(t, http.StatusServiceUnavailable, decision.StatusCode)
+	require.Equal(t, ContentModerationErrorCodeUnavailable, decision.ErrorCode)
 }
 
 func TestContentModerationCheck_KeywordsIgnoredInObserveMode(t *testing.T) {
@@ -982,7 +1007,7 @@ func TestExtractContentModerationInput_AnthropicImageSourceOnlyParticipatesInMem
 	require.NotContains(t, log.InputExcerpt, "aGVsbG8=")
 }
 
-func TestExtractContentModerationInput_AnthropicAuditsSystemRemindersAndEphemeralUserText(t *testing.T) {
+func TestExtractContentModerationInput_AnthropicDropsSystemRemindersAndKeepsEphemeralUserText(t *testing.T) {
 	body := []byte(`{
 		"messages": [
 			{
@@ -998,11 +1023,11 @@ func TestExtractContentModerationInput_AnthropicAuditsSystemRemindersAndEphemera
 
 	input := ExtractContentModerationInput(ContentModerationProtocolAnthropicMessages, body)
 
-	require.Equal(t, "<system-reminder>工具说明</system-reminder> <system-reminder>Ainder> hid", input.Text)
+	require.Equal(t, "hid", input.Text)
 	require.Empty(t, input.Images)
 }
 
-func TestExtractContentModerationInput_OpenAIChatUsesCurrentMessageAndSystemContext(t *testing.T) {
+func TestExtractContentModerationInput_OpenAIChatUsesLatestUserWithoutSystemContext(t *testing.T) {
 	body := []byte(`{
 		"model":"gpt-5.5",
 		"messages":[
@@ -1015,10 +1040,10 @@ func TestExtractContentModerationInput_OpenAIChatUsesCurrentMessageAndSystemCont
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIChat, body)
 
-	require.Equal(t, "latest user system prompt", input.Text)
+	require.Equal(t, "latest user", input.Text)
 	require.Equal(t, []string{"https://example.com/a.png"}, input.Images)
 	require.NotContains(t, input.Text, "old user")
-	require.True(t, strings.HasPrefix(input.Text, "latest user"))
+	require.NotContains(t, input.Text, "system prompt")
 }
 
 func TestExtractContentModerationInput_OpenAIImagesIncludesPromptAndImages(t *testing.T) {
@@ -1068,7 +1093,7 @@ func TestBuildModerationTestInputRejectsMultipleImages(t *testing.T) {
 	require.Contains(t, err.Error(), "最多上传 1 张测试图片")
 }
 
-func TestExtractContentModerationInput_OpenAIResponsesCodexPayloadUsesInstructionsAndCurrentMessage(t *testing.T) {
+func TestExtractContentModerationInput_OpenAIResponsesCodexPayloadUsesLatestUserOnly(t *testing.T) {
 	body := []byte(`{
 		"model":"gpt-5.5",
 		"instructions":"instructions.....",
@@ -1082,9 +1107,11 @@ func TestExtractContentModerationInput_OpenAIResponsesCodexPayloadUsesInstructio
 
 	input := ExtractContentModerationInput(ContentModerationProtocolOpenAIResponses, body)
 
-	require.Equal(t, "last user prompt instructions..... developer permissions sk-proj-1234567890abcdef", input.Text)
+	require.Equal(t, "last user prompt", input.Text)
 	require.Empty(t, input.Images)
 	require.NotContains(t, input.Text, "first user prompt")
+	require.NotContains(t, input.Text, "instructions")
+	require.NotContains(t, input.Text, "developer permissions")
 }
 
 func TestContentModerationCheck_OpenAIResponsesRecordsNonHitForCodexPayload(t *testing.T) {
@@ -1147,8 +1174,8 @@ func TestContentModerationCheck_OpenAIResponsesRecordsNonHitForCodexPayload(t *t
 	require.False(t, logs[0].Flagged)
 	require.Equal(t, ContentModerationActionAllow, logs[0].Action)
 	require.Equal(t, "/responses", logs[0].Endpoint)
-	require.Equal(t, "last user prompt developer instructions must be audited", logs[0].InputExcerpt)
-	require.Equal(t, "last user prompt developer instructions must be audited", moderationRequest.Input)
+	require.Equal(t, "last user prompt", logs[0].InputExcerpt)
+	require.Equal(t, "last user prompt", moderationRequest.Input)
 }
 
 func TestContentModerationCheck_PreBlockBlocksCodexResponsesLatestUserInput(t *testing.T) {
@@ -1216,8 +1243,8 @@ func TestContentModerationCheck_PreBlockBlocksCodexResponsesLatestUserInput(t *t
 	require.True(t, logs[0].Flagged)
 	require.Equal(t, ContentModerationActionBlock, logs[0].Action)
 	require.Equal(t, ContentModerationModePreBlock, logs[0].Mode)
-	require.Equal(t, "latest blocked prompt instructions..... developer instructions must be audited", logs[0].InputExcerpt)
-	require.Equal(t, "latest blocked prompt instructions..... developer instructions must be audited", moderationRequest.Input)
+	require.Equal(t, "latest blocked prompt", logs[0].InputExcerpt)
+	require.Equal(t, "latest blocked prompt", moderationRequest.Input)
 }
 
 func TestContentModerationStatusTracksPreBlockSyncMetrics(t *testing.T) {

--- a/docs/SECURITY_AUDIT_CONTENT_COVERAGE.md
+++ b/docs/SECURITY_AUDIT_CONTENT_COVERAGE.md
@@ -22,18 +22,20 @@ content that is present in an accepted payload.
 
 ## Canonical Result
 
-The shared extractor returns a protocol-independent document containing
-segments with `Text`, `Role`, `Source`, `Current`, and `ClientControlled`, plus
-`ContentBearing` and `Incomplete` classifications.
+The shared extractor returns a protocol-independent document containing text
+segments and image inputs. Both carry `Role`, `Source`, `Current`, and
+`ClientControlled`; the document also carries `ContentBearing` and `Incomplete`
+classifications.
 
 - `Current` identifies the new content in this request or turn. Consecutive
   trailing tool results are all current.
 - `ClientControlled` is independent of the claimed role. A current
   `assistant` or `model` message remains client-controlled inbound content.
 - Structured tool arguments and results are encoded as deterministic JSON.
-- Recognized media blocks are explicit no-text content. Content Moderation
-  preserves its separate image inputs; Prompt Audit does not scan URLs or
-  encoded media as prompt text. Structured results are sanitized before text
+- Recognized media blocks are explicit no-text content. Images remain in the
+  canonical result with the same role, source, and current-turn attribution as
+  their containing item. Prompt Audit does not scan URLs or encoded media as
+  prompt text. Structured results are sanitized before text
   serialization so image/file URLs, data URLs, long base64 payloads, encrypted
   compaction data, screenshots, and image-generation results are not persisted;
   ordinary text beside those fields remains auditable.
@@ -80,9 +82,18 @@ Both engines consume the same canonical document:
 
 | Engine/mode | Segment selection |
 | --- | --- |
-| Content Moderation | Scans current segments, with current messages and tool results placed before repeated context; image extraction follows the same current rule, including consecutive Chat/Responses tool outputs, nested Anthropic tool results, reusable prompt variables, and computer screenshots |
+| Content Moderation | Scans only current direct-user text and images. Chat and Anthropic require an explicit `user` role; Responses, Live, and Gemini also accept their protocol-defined roleless user forms. Direct Alpha Search queries, embedding strings, and media prompts remain eligible. Instructions, system/developer context, reusable prompt variables, assistant/model messages, reasoning, tool definitions/calls/results, approval responses, and tool-produced images are excluded so platform or external content is not attributed to the user. |
 | Prompt Audit full/async | Scans all canonical segments subject to existing size, redaction, and persistence rules |
 | Prompt Audit blocking latest-turn-only | Prioritizes current client-controlled segments, then current instructions/tool definitions and the nearest relevant prior assistant/model output; it never trusts the inbound role to select an older user turn |
+
+Sharing a canonical document does not mean that the engines select identical
+segments. Prompt Audit provides full security-boundary visibility, while
+Content Moderation preserves the `v0.1.177+custom.003` attribution rule: only a
+direct user submission may produce a user content-policy violation. A turn
+containing only a tool result, assistant/model content, or platform context is
+a valid empty Content Moderation selection, but remains visible to Prompt
+Audit. Incomplete canonical extraction is still an extraction failure for both
+engines before either selection policy is applied.
 
 ## Failure Semantics
 

--- a/docs/protocols/OPENAI_RESPONSES.md
+++ b/docs/protocols/OPENAI_RESPONSES.md
@@ -139,22 +139,26 @@ Audit before account selection, billing, concurrency acquisition, fingerprint
 convergence, request adaptation, or upstream writes. API-key and OAuth account
 paths therefore use the same audit content.
 
-The boundary covers top-level and `response`-nested `instructions`, `tools`,
-`input`, reusable `prompt.variables`, message text, tool definitions, and the
-arguments, input, output, result, or dynamic tools carried by function, custom,
-tool-search, local/hosted shell, apply-patch, computer, MCP, code-interpreter,
-and programmatic-tool-calling items. In particular,
+The canonical boundary covers top-level and `response`-nested `instructions`,
+`tools`, `input`, reusable `prompt.variables`, message text, tool definitions,
+and the arguments, input, output, result, or dynamic tools carried by function,
+custom, tool-search, local/hosted shell, apply-patch, computer, MCP,
+code-interpreter, and programmatic-tool-calling items. In particular,
 `function_call_output.output`,
 `custom_tool_call_output.output`, the compatibility
 `tool_search_output.output`, and official `tool_search_output.tools` are
-audited on every HTTP or WebSocket turn. Media fields and encoded screenshots
-remain Content Moderation image inputs but are removed before Prompt Audit text
-serialization and persistence; ordinary text in the same structured result is
-retained.
-The current input item remains client-controlled even when it claims an
-`assistant` role; role labels cannot force latest-turn auditing to scan an old
-user message instead. Current message/tool content is scanned before repeated
-instructions and tool definitions, while all context remains included.
+available to Prompt Audit on every HTTP or WebSocket turn. Media fields and
+encoded screenshots are removed before Prompt Audit text serialization and
+persistence; ordinary text in the same structured result is retained.
+
+Content Moderation consumes the same canonical result but selects only the
+current direct-user message text and images. It excludes `instructions`, tool
+definitions, reusable prompt variables, assistant/model messages, reasoning,
+tool calls/results, approval responses, and tool-produced screenshots. This
+prevents platform context or external tool content from being reported as a
+user policy violation. Prompt Audit continues to cover those excluded segments;
+its latest-turn mode treats a current client-submitted `assistant` item as
+untrusted and prioritizes it instead of falling back to an older user message.
 A supported WebSocket control frame is an explicit no-content case only when it
 contains no canonical content fields or unknown non-empty siblings. An envelope
 `type` value never suppresses `input`, `instructions`, or nested

--- a/openspec/changes/harden-security-audit-content-extraction/design.md
+++ b/openspec/changes/harden-security-audit-content-extraction/design.md
@@ -9,11 +9,12 @@
 新增 `internal/auditcontent`，只依赖标准库并暴露稳定的协议无关结果：
 
 ```text
-Document{Segments, ContentBearing, Incomplete}
+Document{Segments, Images, ContentBearing, Incomplete}
 Segment{Text, Role, Source, Current, ClientControlled}
+Image{URL, Role, Source, Current, ClientControlled}
 ```
 
-`Source` 区分 message、instruction、tool_definition、tool_output、tool_call、search_query、embedding_input 和 media_prompt。`Current` 标记本次新增增量，供 Content Moderation 避免重复扫描历史；`ClientControlled` 标记应在最新轮阻断策略中优先扫描的内容。入口角色标签不构成信任边界，当前 assistant/model 段同样属于客户端控制内容。
+`Source` 区分 message、instruction、tool_definition、tool_output、tool_call、search_query、embedding_input、media_prompt、prompt_variable 和 reasoning。`Current` 标记本次新增增量；`ClientControlled` 标记应在 Prompt Audit 最新轮阻断策略中优先扫描的内容。入口角色标签不构成 Prompt Audit 的信任边界，当前 assistant/model 段同样属于客户端控制内容。图片保留与所属内容项相同的角色、来源和当前轮属性，避免文本和图片使用两套协议解析器。
 
 共享包不依赖 `service` 或 `securityaudit`，避免包环；它不执行风险判断、脱敏、持久化、采样或副作用。
 
@@ -21,7 +22,9 @@ Segment{Text, Role, Source, Current, ClientControlled}
 
 Prompt Audit 消费所有规范化段，并继续按最新客户端输入优先生成快照。启用 `blocking_latest_turn_only` 时，选择当前客户端控制段、当前 instructions/工具定义上下文及其最近的历史 assistant/model 输出。
 
-Content Moderation 只消费 `Current` 段，保持避免重复审核历史的目标，但当前工具输出、搜索查询、instructions、工具定义和 embedding 输入都属于 Current。当前消息/工具结果先于重复上下文进入有界审核输入。图像路径独立于文本序列化，但复用同一 Current 规则：Chat/Responses 尾部连续工具输出、Anthropic 最后一条消息中的嵌套 tool result、Responses reusable prompt variables 和 computer screenshot 都可产生图片输入。
+Content Moderation 在同一规范化结果上执行独立的直接用户归因选择，恢复 `v0.1.177+custom.003` 的产品语义：普通消息协议只选择最后一个当前直接用户消息中的文本和图片；Chat/Anthropic 要求显式 `user` 角色，Responses/Live/Gemini 允许其协议定义的无角色用户简写。Alpha Search 查询、Embeddings 字符串和 Images/media prompt 属于直接用户输入。instructions、system/developer 上下文、assistant/model 消息、reasoning、工具定义/调用/结果、审批响应、reusable prompt variables 及其图片均不进入 Content Moderation，避免把平台或外部内容归因为用户违规。它们仍完整保留给 Prompt Audit。
+
+规范化成功但没有直接用户内容时，Content Moderation 产生合法空选择并跳过外部 Moderations 请求。`Incomplete=true` 的检查发生在引擎选择之前，因此未知内容或部分提取仍按配置模式记录失败或 fail closed，不能以空选择绕过。
 
 ### 3. 明确协议覆盖
 
@@ -34,15 +37,15 @@ Content Moderation 只消费 `Current` 段，保持避免重复审核历史的�
 - Embeddings：input 字符串或字符串数组。
 - Images/media：确定性的 prompt 类文本键，排除 URL 和大块媒体载荷。
 
-结构化工具参数和输出先移除图片/文件 URL、data URL、长 base64、encrypted content、computer screenshot 和 image-generation binary result，再采用确定性 JSON 编码审核；同一结构中的普通文本必须保留。这样 Prompt Audit 不会持久化媒体或不透明载荷，Content Moderation 仍可从独立图片路径审核图像。
+结构化工具参数和输出先移除图片/文件 URL、data URL、长 base64、encrypted content、computer screenshot 和 image-generation binary result，再采用确定性 JSON 编码审核；同一结构中的普通文本必须保留。这样 Prompt Audit 不会持久化媒体或不透明载荷，规范化图片仍保留来源归因；Content Moderation 只选择直接用户图片，不选择工具输出或 prompt variable 图片。
 
-已识别的纯图片块属于显式无文本，但仍由 Content Moderation 的图像输入审核。Embeddings token-ID 数组无法在无模型 tokenizer 的共享层可靠还原，因此不得把数字 JSON 当作已审核文本；阻断模式按提取失败处理。
+已识别的纯图片块属于显式无文本；其中只有当前直接用户图片由 Content Moderation 的图像输入审核。Embeddings token-ID 数组无法在无模型 tokenizer 的共享层可靠还原，因此不得把数字 JSON 当作已审核文本；阻断模式按提取失败处理。
 
 ### 4. 内容承载分类与失败语义
 
 共享解析器在认识到协议字段或内容项存在时设置 `ContentBearing=true`。只有已明确分类且实际不含内容字段的 WebSocket 控制帧、空控制对象和没有内容字段的请求可以是非内容承载；顶层 `type` 值不能压制同一载荷中实际存在的 `input`、`instructions` 或嵌套 `response.input`。
 
-已知消息、item 和 control 类型使用允许字段集合。任何未知非空兄弟字段都会设置 `Incomplete=true`，不能被已经成功提取的正文掩盖。若 `Incomplete=true`，或 `ContentBearing=true` 但没有可审核段，即使同一载荷的其他兄弟项已成功提取也属于提取失败：
+已知消息、item 和 control 类型使用允许字段集合。任何未知非空兄弟字段都会设置 `Incomplete=true`，不能被已经成功提取的正文掩盖。若 `Incomplete=true`，或 `ContentBearing=true` 但既没有可审核文本段也没有已识别图片，即使同一载荷的其他兄弟项已成功提取也属于提取失败。规范化成功后，某个引擎因自身归因策略选择为空不属于提取失败：
 
 Responses HTTP 根对象、嵌套 `response`、Responses/Live session 及 Live 转录配置都遵循相同规则。Live 初始 HTTP session 和 Sideband 必须选择 `openai_live` 适配器；适配器同时审核旧式 `input_audio_transcription.prompt`/`keywords` 与现行 `audio.input.transcription.prompt`/`keywords`。结构化内容清洗后的 JSON 序列化失败同样设置 `Incomplete=true`，不得静默返回。
 
@@ -64,8 +67,8 @@ Content Moderation 的 503 使用 `content_moderation_unavailable`；命中内�
 建立真实载荷表驱动测试，并对每个载荷同时断言：
 
 - 共享解析结果非空且当前增量正确。
-- Content Moderation 输入非空。
-- Prompt Audit 快照非空，latest-turn 策略包含当前工具/搜索内容。
+- Content Moderation 对直接用户载荷输入非空，对 instructions、assistant/model、工具结果和 prompt variables 为空。
+- Prompt Audit 快照保持非空，latest-turn 策略包含当前工具/搜索内容。
 - HTTP 与 WebSocket 审核仍位于账号、计费、并发和上游副作用之前。
 - Live Sideband 的客户端帧审核 hook 位于 `upstream.WriteFrame` 之前。
 - Responses passthrough 的所有客户端数据帧进入审核 hook；非 create 帧被拒绝时上游写计数为零。

--- a/openspec/changes/harden-security-audit-content-extraction/proposal.md
+++ b/openspec/changes/harden-security-audit-content-extraction/proposal.md
@@ -7,11 +7,11 @@
 ## What Changes
 
 - 新增独立共享的安全审核内容提取包，统一解析协议、角色、当前请求增量、instructions、工具定义、工具结果和文本来源。
-- Content Moderation 与 Prompt Audit 共同消费共享提取结果；两者保留各自的风险模型、配置、持久化和副作用。
+- Content Moderation 与 Prompt Audit 共同消费共享提取结果，但保留不同选择策略：Content Moderation 只归因当前直接用户文本/图片，Prompt Audit 保持完整规范化覆盖。
 - 覆盖 Responses HTTP/WS 顶层、`response.*`、session-update 载荷、`prompt.variables`、官方 shell/computer/MCP/PTC/tool-search 形态、Alpha Search、Live 初始 session、新旧转录 prompt/keywords 与每个 Sideband/Responses passthrough 客户端数据帧、Embeddings 字符串数组，以及 Chat/Anthropic/Gemini 工具结果。
-- 结构化文本审核前剥离媒体 URL、data URL、长 base64 和加密载荷；Content Moderation 图片路径复用 canonical current 规则。
+- 结构化文本审核前剥离媒体 URL、data URL、长 base64 和加密载荷；规范化结果为图片保留角色、来源和当前轮归因，Content Moderation 只选择直接用户图片。
 - Content Moderation 提取不可用在协调器中分类为 unavailable；confirmed policy match 才分类为 block。
-- 将入口当前增量（包括伪装为 assistant/model 的消息）和工具结果视为客户端控制输入；阻断模式的 latest-turn 策略必须优先扫描当前增量，而不是回退到历史用户消息。
+- 将入口当前增量（包括伪装为 assistant/model 的消息）和工具结果视为 Prompt Audit 的客户端控制输入；阻断模式的 latest-turn 策略必须优先扫描当前增量，而不是回退到历史用户消息。Content Moderation 排除 assistant/model、instructions、工具内容和 reusable prompt variables，避免将平台或外部内容报告为用户违规。
 - 区分显式控制帧与内容承载载荷。请求根对象、嵌套 response/session 和转录配置的未知非空兄弟字段，以及结构化内容规范化或序列化失败，都必须产生不完整提取；启用阻断审核时必须在任何账号、计费或上游副作用前拒绝。
 - 增加真实协议载荷的双引擎语义测试和提取尝试、成功、空内容、失败计数。
 - 固化仓库级不可绕过安全审核规约，使任何协议、账号、会话、路由或转换变更必须同步更新覆盖矩阵和测试。

--- a/openspec/changes/harden-security-audit-content-extraction/specs/security-audit-content-coverage/spec.md
+++ b/openspec/changes/harden-security-audit-content-extraction/specs/security-audit-content-coverage/spec.md
@@ -14,17 +14,33 @@ Content Moderation and Prompt Audit SHALL consume the same canonical protocol ex
 
 - **WHEN** a supported endpoint begins accepting a new user, tool, search, instruction, or structured content field
 - **THEN** the canonical extraction contract and real-payload tests MUST be updated in the same change
-- **THEN** both audit engines MUST receive the new field without independent parser changes
+- **THEN** the field MUST be available to both audit-engine selection policies without independent protocol parsers
 
-### Requirement: Tool and external-source results must be audited as current input
+### Requirement: Content Moderation must use direct-user attribution
 
-Client-submitted tool results and other external-source content SHALL be classified as current client-controlled input. Structured results MUST be converted to deterministic text without logging their raw content.
+Content Moderation SHALL select only current direct-user text and images from the canonical result. Prompt Audit SHALL retain complete canonical coverage. A valid canonical document that contains only content excluded by Content Moderation is an ordinary empty moderation selection, not an extraction failure.
+
+#### Scenario: Platform context accompanies a user message
+
+- **WHEN** a request contains a current direct-user message together with instructions, system/developer context, tool definitions, reusable prompt variables, reasoning, or historical content
+- **THEN** Content Moderation MUST include only the current direct-user message text and images
+- **THEN** Prompt Audit MUST retain the canonical context required by its full or latest-turn policy
+
+#### Scenario: A turn has no direct-user submission
+
+- **WHEN** a valid turn contains only assistant/model content, tool calls/results, approvals, instructions, or prompt variables
+- **THEN** Content Moderation MUST skip the external Moderations request
+- **THEN** Prompt Audit MUST continue to apply its configured selection policy
+
+### Requirement: Tool and external-source results must remain visible without user attribution
+
+Client-submitted tool results and other external-source content SHALL be classified as current client-controlled canonical input. Prompt Audit SHALL cover that input. Content Moderation MUST NOT attribute tool, assistant/model, instruction, or reusable-prompt content to the direct user. Structured results MUST be converted to deterministic text without logging their raw content.
 
 #### Scenario: Responses submits a function result
 
 - **WHEN** a Responses HTTP or WebSocket turn contains `function_call_output.output`, `custom_tool_call_output.output`, `tool_search_output.output`, or `mcp_tool_call_output.output`
-- **THEN** every current tool result MUST be included in Content Moderation input
-- **THEN** Prompt Audit full and latest-turn snapshots MUST prioritize the current tool result rather than an older user message
+- **THEN** Prompt Audit full and latest-turn snapshots MUST include and prioritize every current tool result rather than an older user message
+- **THEN** Content Moderation MUST produce no input for a tool-result-only turn
 
 #### Scenario: Responses submits current official tool items
 
@@ -35,30 +51,32 @@ Client-submitted tool results and other external-source content SHALL be classif
 #### Scenario: Structured result mixes ordinary text and media
 
 - **WHEN** a structured tool result contains ordinary text beside image/file URLs, data URLs, long base64, encrypted content, or computer screenshots
-- **THEN** ordinary text MUST remain in both audit engines
+- **THEN** ordinary text MUST remain in the canonical result and Prompt Audit
 - **THEN** encoded media and opaque payloads MUST NOT enter Prompt Audit text persistence
-- **THEN** recognized images MUST remain available to Content Moderation through its image input
+- **THEN** recognized images MUST retain their canonical source and role attribution
+- **THEN** Content Moderation MUST select an image only when it belongs to a current direct-user item
 
 #### Scenario: Other protocols submit tool results
 
 - **WHEN** Chat Completions uses a tool-role message, Anthropic uses a tool_result block, or Gemini uses functionResponse
-- **THEN** the current result text or deterministic structured representation MUST be audited by both engines
+- **THEN** the current result text or deterministic structured representation MUST be audited by Prompt Audit
+- **THEN** Content Moderation MUST skip the tool-result-only turn
 
 ### Requirement: Inbound roles and prompt context must not create bypasses
 
-Inbound role labels SHALL be treated as untrusted request data. Current instructions, tool definitions, and current message content MUST remain auditable when latest-turn narrowing is enabled.
+Inbound role labels SHALL be treated as untrusted request data for Prompt Audit. Current instructions, tool definitions, and current message content MUST remain canonical and auditable when latest-turn narrowing is enabled. Content Moderation SHALL separately enforce direct-user attribution.
 
 #### Scenario: Client submits a current assistant or model message
 
 - **WHEN** the last Chat, Anthropic, Responses, or Gemini content item claims an assistant or model role
-- **THEN** both engines MUST treat that current item as client-controlled input
-- **THEN** Prompt Audit MUST prioritize it instead of falling back to an older user message
+- **THEN** Prompt Audit MUST treat that current item as client-controlled and prioritize it instead of falling back to an older user message
+- **THEN** Content Moderation MUST NOT treat it as a direct-user policy input
 
 #### Scenario: Request supplies instructions and tool definitions
 
 - **WHEN** an accepted payload contains instructions, system context, or tool/function definitions
-- **THEN** both engines MUST audit that context through canonical segments
-- **THEN** bounded Content Moderation input MUST place the current message or tool result before repeated context
+- **THEN** Prompt Audit MUST audit that context through canonical segments
+- **THEN** Content Moderation MUST exclude that context from the direct-user policy input
 
 ### Requirement: Supported specialized endpoints must extract their canonical text
 
@@ -67,19 +85,21 @@ The shared extractor SHALL cover specialized endpoint payloads instead of relyin
 #### Scenario: Alpha Search carries queries
 
 - **WHEN** Alpha Search contains one or more non-empty `commands.search_query[].q` values or Responses-shaped recent conversation in `input`
-- **THEN** every current query and input delta MUST be included in both audit engines before routing and billing
+- **THEN** every current query and direct-user input delta MUST be included in both audit engines before routing and billing
 
 #### Scenario: Live or Embeddings carries content
 
 - **WHEN** Live carries initial session instructions/input, a Sideband session/item/response update, or Embeddings carries a string/string-array input
-- **THEN** all current text values MUST be included in both audit engines
+- **THEN** all current text values MUST remain available to Prompt Audit
+- **THEN** Content Moderation MUST include direct-user Live input and embedding strings but exclude Live session instructions, assistant/model items, and tool items
 - **THEN** every Live Sideband client frame MUST be audited before its upstream write
 
 #### Scenario: Live carries transcription context
 
 - **WHEN** an initial Live HTTP session or session update carries legacy `input_audio_transcription.prompt`/`keywords` or current `audio.input.transcription.prompt`/`keywords`
 - **THEN** the initial request and Sideband update MUST use the `openai_live` adapter
-- **THEN** every prompt and keyword MUST be included in both audit engines before billing, concurrency acquisition, or an upstream write
+- **THEN** every prompt and keyword MUST be included in Prompt Audit before billing, concurrency acquisition, or an upstream write
+- **THEN** Content Moderation MUST exclude that transcription configuration from direct-user policy input
 
 #### Scenario: Responses WebSocket uses a nested envelope
 
@@ -95,7 +115,7 @@ The shared extractor SHALL cover specialized endpoint payloads instead of relyin
 
 ### Requirement: Content-bearing extraction failures must be visible and fail closed in blocking mode
 
-Every enabled audit engine SHALL count extraction attempts, successes, empty control cases, and failures. A payload classified as content-bearing but producing no auditable segment, or containing any non-empty content item that cannot be completely normalized, SHALL be an extraction failure, not an ordinary empty or successful request. Extractable sibling items MUST NOT hide a partial extraction failure.
+Every enabled audit engine SHALL count extraction attempts, successes, empty selections, and failures. A canonical payload classified as content-bearing but producing neither an auditable text segment nor a recognized image, or containing any non-empty content item that cannot be completely normalized, SHALL be an extraction failure, not an ordinary empty or successful request. Extractable sibling items MUST NOT hide a partial extraction failure. After successful canonical extraction, an engine MAY select no content when its documented attribution policy excludes every canonical item.
 
 #### Scenario: Observe mode cannot extract expected content
 
@@ -160,7 +180,8 @@ Every supported content-bearing endpoint and payload family SHALL have tests usi
 
 - **WHEN** the security-audit test suite runs
 - **THEN** it MUST pass real payloads through the canonical extractor, Content Moderation, and Prompt Audit
-- **THEN** it MUST assert non-empty expected current content and correct tool-result priority
+- **THEN** it MUST assert Prompt Audit coverage and correct tool-result priority
+- **THEN** it MUST assert that Content Moderation includes direct-user input while excluding instructions, assistant/model content, reusable prompt variables, and tool content
 
 #### Scenario: Gateway ordering test executes
 

--- a/openspec/changes/harden-security-audit-content-extraction/tasks.md
+++ b/openspec/changes/harden-security-audit-content-extraction/tasks.md
@@ -8,7 +8,8 @@
 
 - [x] 2.1 Add the dependency-free canonical audit-content parser and real-payload unit tests.
 - [x] 2.2 Move Prompt Audit protocol text extraction onto canonical segments without changing redaction, hashing, persistence, or scanner behavior.
-- [x] 2.3 Move Content Moderation text extraction onto canonical current segments while preserving image handling and risk side effects.
+- [x] 2.3 Move Content Moderation extraction onto a canonical-document selector while preserving risk side effects.
+- [x] 2.4 Preserve canonical image attribution and restore Content Moderation to current direct-user selection without narrowing Prompt Audit coverage.
 
 ## 3. Security behavior and observability
 
@@ -23,3 +24,4 @@
 
 - [x] 4.1 Add dual-engine semantic payload-contract tests and update obsolete tests that codified tool-loop skips.
 - [x] 4.2 Run gofmt, focused audit/service/handler tests, OpenSpec strict validation, AGENTS format validation, and `git diff --check`.
+- [x] 4.3 Add regression coverage proving platform context and tool-only turns do not become Content Moderation violations while incomplete extraction still fails closed.


### PR DESCRIPTION
## Summary

Submit `fix/security-audit-direct-user-moderation` after the repository local-validation gate.

## Validation

- Platform-container validation matrix passed.

<!-- sub2api-submit-pr: {"base":"ad60a360e6fc00353629229d8fc01e389f93ba38","head":"ab66114d3c0863f2b12a0f043ab9c87569defe53"} -->
