### PR TITLE
docs(release): mark v0.1.178+custom.004 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -43,7 +43,7 @@ procedures are documented in [`docs/RELEASING.md`](docs/RELEASING.md).
 | `v0.1.178+custom.001` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | published |
 | `v0.1.178+custom.002` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | published |
 | `v0.1.178+custom.003` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | published |
-| `v0.1.178+custom.004` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | planned |
+| `v0.1.178+custom.004` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.1.178-custom.004` after the repository local-validation gate.

## Validation

- Deterministic finalization for `v0.1.178+custom.004` passed.

<!-- sub2api-submit-pr: {"base":"89c9da6a472e24524e58c77bd9dceda79395f4fb","head":"474f87ee9f6f1e30e80c02bea84f9517f5e28b92","profile":"release-finalization","tag":"v0.1.178+custom.004"} -->
