### PR TITLE
docs(release): mark v0.1.178+custom.005 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -44,7 +44,7 @@ procedures are documented in [`docs/RELEASING.md`](docs/RELEASING.md).
 | `v0.1.178+custom.002` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | published |
 | `v0.1.178+custom.003` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | published |
 | `v0.1.178+custom.004` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | published |
-| `v0.1.178+custom.005` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | planned |
+| `v0.1.178+custom.005` | `v0.1.178` | `e0c48a19ed794a565e3858662520afe0a1f9f0ba` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.1.178-custom.005` after the repository local-validation gate.

## Validation

- Deterministic finalization for `v0.1.178+custom.005` passed.

<!-- sub2api-submit-pr: {"base":"594d5fb2526ce4981d1ad06cd83893f075f494bb","head":"4b16e6c849fb194dc728c457aa71e16fe3d18986","profile":"release-finalization","tag":"v0.1.178+custom.005"} -->
