### PR TITLE
docs(release): mark v0.1.183+custom.004 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -48,7 +48,7 @@ procedures are documented in [`docs/RELEASING.md`](docs/RELEASING.md).
 | `v0.1.183+custom.001` | `v0.1.183` | `e8cb019fabf8b55199436229044cbf9aa7a82564` | published |
 | `v0.1.183+custom.002` | `v0.1.183` | `e8cb019fabf8b55199436229044cbf9aa7a82564` | published |
 | `v0.1.183+custom.003` | `v0.1.183` | `e8cb019fabf8b55199436229044cbf9aa7a82564` | published |
-| `v0.1.183+custom.004` | `v0.1.183` | `e8cb019fabf8b55199436229044cbf9aa7a82564` | planned |
+| `v0.1.183+custom.004` | `v0.1.183` | `e8cb019fabf8b55199436229044cbf9aa7a82564` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.1.183-custom.004` after the repository local-validation gate.

## Validation

- Deterministic finalization for `v0.1.183+custom.004` passed.

<!-- sub2api-submit-pr: {"base":"6c1e6d69398398022a832f869cdb70e69ba47c4d","head":"bb3ee5d5ce4093e8e688957635aa38f9bdbbfa6c","profile":"release-finalization","tag":"v0.1.183+custom.004"} -->
