### PR TITLE
docs(release): mark v0.2.0+custom.002 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -50,7 +50,7 @@ procedures are documented in [`docs/RELEASING.md`](docs/RELEASING.md).
 | `v0.1.183+custom.003` | `v0.1.183` | `e8cb019fabf8b55199436229044cbf9aa7a82564` | published |
 | `v0.1.183+custom.004` | `v0.1.183` | `e8cb019fabf8b55199436229044cbf9aa7a82564` | published |
 | `v0.2.0+custom.001` | `v0.2.0` | `aa236488351eb71e120fc2b6fb32e36b0374c918` | published |
-| `v0.2.0+custom.002` | `v0.2.0` | `aa236488351eb71e120fc2b6fb32e36b0374c918` | planned |
+| `v0.2.0+custom.002` | `v0.2.0` | `aa236488351eb71e120fc2b6fb32e36b0374c918` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.2.0-custom.002` after the repository local-validation gate.

## Validation

- Deterministic finalization for `v0.2.0+custom.002` passed.

<!-- sub2api-submit-pr: {"base":"cd1d8438cbe19358936605af7e6b20954283bf15","head":"d3e248405815be8516de1e3fb55b907cf04c1d6a","profile":"release-finalization","tag":"v0.2.0+custom.002"} -->
