### PR TITLE
docs(release): mark v0.2.1+custom.002 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -53,7 +53,7 @@ procedures are documented in [`docs/RELEASING.md`](docs/RELEASING.md).
 | `v0.2.0+custom.002` | `v0.2.0` | `aa236488351eb71e120fc2b6fb32e36b0374c918` | published |
 | `v0.2.0+custom.003` | `v0.2.0` | `aa236488351eb71e120fc2b6fb32e36b0374c918` | published |
 | `v0.2.1+custom.001` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
-| `v0.2.1+custom.002` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | planned |
+| `v0.2.1+custom.002` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.2.1-custom.002` after the repository local-validation gate.

## Validation

- Deterministic finalization for `v0.2.1+custom.002` passed.

<!-- sub2api-submit-pr: {"base":"1b95c72f186275f582714bed38a1a4af122429f1","head":"78b1c16673132fb210d676b4ee4539f553063822","profile":"release-finalization","tag":"v0.2.1+custom.002"} -->
