### PR TITLE
docs(release): mark v0.2.1+custom.003 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -54,7 +54,7 @@ procedures are documented in [`docs/RELEASING.md`](docs/RELEASING.md).
 | `v0.2.0+custom.003` | `v0.2.0` | `aa236488351eb71e120fc2b6fb32e36b0374c918` | published |
 | `v0.2.1+custom.001` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
 | `v0.2.1+custom.002` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
-| `v0.2.1+custom.003` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | planned |
+| `v0.2.1+custom.003` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.2.1-custom.003` after the repository local-validation gate.

## Validation

- Deterministic finalization for `v0.2.1+custom.003` passed.

<!-- sub2api-submit-pr: {"base":"94beb01630fa163bc7c112202eafd9b8946ca725","head":"c8fda640a429f9666d16e9813db16f21d792be21","profile":"release-finalization","tag":"v0.2.1+custom.003"} -->
