### PR TITLE
docs(release): mark v0.2.4+custom.001 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -73,7 +73,7 @@ for public API changes, migrations, defaults, and validation boundaries.
 | `v0.2.1+custom.001` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
 | `v0.2.1+custom.002` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
 | `v0.2.1+custom.003` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
-| `v0.2.4+custom.001` | `v0.2.4` | `5de5e2bed035d43591a2e10e51f420ef6a84eb98` | planned |
+| `v0.2.4+custom.001` | `v0.2.4` | `5de5e2bed035d43591a2e10e51f420ef6a84eb98` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.2.4-custom.001` after the repository local-validation gate.

## Validation

- Deterministic finalization for `v0.2.4+custom.001` passed.

<!-- sub2api-submit-pr: {"base":"92e12acd4b39f030b56e635bcc02e239e14843e9","head":"95d6ad0525052ede2c2fad55957fcbb7242f0def","profile":"release-finalization","tag":"v0.2.4+custom.001"} -->
