### PR TITLE
docs(release): mark v0.2.4+custom.002 published

### DIFF
--- a/UPSTREAM.md
+++ b/UPSTREAM.md
@@ -74,7 +74,7 @@ for public API changes, migrations, defaults, and validation boundaries.
 | `v0.2.1+custom.002` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
 | `v0.2.1+custom.003` | `v0.2.1` | `578785ee7fb35030b094b69624efe25670a36f5f` | published |
 | `v0.2.4+custom.001` | `v0.2.4` | `5de5e2bed035d43591a2e10e51f420ef6a84eb98` | published |
-| `v0.2.4+custom.002` | `v0.2.4` | `5de5e2bed035d43591a2e10e51f420ef6a84eb98` | planned |
+| `v0.2.4+custom.002` | `v0.2.4` | `5de5e2bed035d43591a2e10e51f420ef6a84eb98` | published |
 
 `v0.1.166+custom.007` is marked invalid because its tag contains embedded and
 documented version `0.1.166+custom.006`. Remote Release and OCI artifact status


### PR DESCRIPTION
## Summary

Submit `release/finalize-0.2.4-custom.002` after the repository local-validation gate.

## Validation

- Deterministic finalization for `v0.2.4+custom.002` passed.

<!-- sub2api-submit-pr: {"base":"fdb9c6de8a959056d6678778979b60c0b0bf20e6","head":"800f3e92e590811d8e83f958a9981bb6bc12417f","profile":"release-finalization","tag":"v0.2.4+custom.002"} -->
